### PR TITLE
More tests and some linting

### DIFF
--- a/odc/index/__init__.py
+++ b/odc/index/__init__.py
@@ -1,5 +1,4 @@
-""" Indexing related helper methods.
-"""
+"""Indexing related helper methods."""
 from ._grouper import group_by_nothing, solar_offset
 from ._index import (
     all_datasets,

--- a/odc/index/_grouper.py
+++ b/odc/index/_grouper.py
@@ -1,6 +1,4 @@
-"""
-Methods for grouping Datasets spatialy and otherwise
-"""
+"""Methods for grouping Datasets spatialy and otherwise."""
 from datetime import timedelta
 from typing import Any, Dict, Hashable, Iterable, Iterator, List, Optional
 
@@ -13,9 +11,7 @@ from datacube.utils.geometry import Geometry
 
 
 def mid_longitude(geom: Geometry) -> float:
-    """
-    Returns longitude of the middle point of the geomtry
-    """
+    """Return longitude of the middle point of the geomtry."""
     ((lon,), _) = geom.centroid.to_crs("epsg:4326").xy
     return lon
 
@@ -41,6 +37,7 @@ def key2num(
 ) -> Iterator[int]:
     """
     Given a sequence of hashable objects return sequence of numeric ids starting from 0.
+
     For example ``'A' 'B' 'A' 'A' 'C' -> 0 1 0 0 2``
     """
     o2id: Dict[Any, int] = {}
@@ -58,13 +55,15 @@ def group_by_nothing(
     dss: List[Dataset], solar_day_offset: Optional[timedelta] = None
 ) -> xr.DataArray:
     """
+    No op grouping of datasets.
+
     Construct "sources" just like ``.group_dataset`` but with every slice
     containing just one Dataset object wrapped in a tuple.
 
     Time -> (Dataset,)
     """
-    dss = sorted(dss, key=lambda ds: (normalise_dt(ds.center_time), ds.id))
-    time = [normalise_dt(ds.center_time) for ds in dss]
+    dss = sorted(dss, key=lambda ds: (normalise_dt(ds.center_time), ds.id))  # type: ignore
+    time = [normalise_dt(ds.center_time) for ds in dss]  # type: ignore
     solar_day = None
 
     if solar_day_offset is not None:

--- a/odc/index/_index.py
+++ b/odc/index/_index.py
@@ -202,7 +202,7 @@ def season_range(year: int, season: str) -> Tuple[datetime.datetime, datetime.da
 
     DJF for year X starts in Dec X-1 and ends in Feb X.
     """
-    seasons = dict(djf=-1, mam=2, jja=6, son=9)
+    seasons = dict(djf=-1, mam=3, jja=6, son=9)
 
     start_month = seasons.get(season.lower())
     if start_month is None:

--- a/odc/index/_uuid.py
+++ b/odc/index/_uuid.py
@@ -1,6 +1,4 @@
-"""
-Determenistic UUID generation for Datasets
-"""
+"""Determenistic UUID generation for Datasets."""
 import uuid
 from typing import Sequence
 from uuid import UUID
@@ -16,7 +14,8 @@ def odc_uuid(
     deployment_id: str = "",
     **other_tags,
 ) -> UUID:
-    """Generate deterministic UUID for a derived Dataset
+    """
+    Generate deterministic UUID for a derived Dataset.
 
     :param algorithm: Name of the algorithm
     :param algorithm_version: Version string of the algorithm

--- a/odc/stac/__init__.py
+++ b/odc/stac/__init__.py
@@ -1,6 +1,4 @@
-"""
-STAC Item -> ODC Dataset[eo3]
-"""
+"""STAC Item -> ODC Dataset[eo3]."""
 from ._version import __version__  # isort:skip  this has to be 1st import
 from ._dcload import dc_load
 from ._eo3 import BandMetadata, ConversionConfig, infer_dc_product, stac2ds

--- a/odc/stac/_dcload.py
+++ b/odc/stac/_dcload.py
@@ -1,7 +1,4 @@
-"""
-Wrapper for Datacube.load_data
-
-"""
+"""Wrapper for Datacube.load_data."""
 from typing import Any, Callable, Dict, Iterable, Optional, Sequence, Union
 from warnings import warn
 
@@ -10,6 +7,7 @@ from datacube import Datacube
 from datacube.api.core import output_geobox
 from datacube.model import Dataset
 from datacube.utils.geometry import GeoBox
+
 
 # pylint: disable=too-many-arguments
 def dc_load(
@@ -24,9 +22,7 @@ def dc_load(
     fuse_func=None,
     **kw,
 ) -> xr.Dataset:
-    """
-    Load data given a collection of datacube.Dataset objects.
-    """
+    """Load data given a collection of datacube.Dataset objects."""
     datasets = list(datasets)
     assert len(datasets) > 0
 

--- a/odc/stac/_version.py
+++ b/odc/stac/_version.py
@@ -1,4 +1,2 @@
-"""
-version information only
-"""
+"""version information only."""
 __version__ = "0.2.0a9"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,11 @@ LIDAR_STAC: str = "lidar_dem.json"
 # pylint: disable=redefined-outer-name
 
 
+@pytest.fixture(scope="session")
+def test_data_dir():
+    return TEST_DATA_FOLDER
+
+
 @pytest.fixture
 def usgs_landsat_stac():
     with TEST_DATA_FOLDER.joinpath(USGS_LANDSAT_STAC).open("r") as f:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,8 @@ import json
 from pathlib import Path
 
 import pystac
+import pystac.collection
+import pystac.item
 import pytest
 from datacube.utils import documents
 
@@ -78,14 +80,14 @@ def sentinel_stac_ms_no_ext():
 
 @pytest.fixture
 def sentinel_stac_ms_with_raster_ext():
-    return pystac.Item.from_file(
+    return pystac.item.Item.from_file(
         str(TEST_DATA_FOLDER.joinpath(SENTINEL_STAC_MS_RASTER_EXT))
     )
 
 
 @pytest.fixture
 def sentinel_stac_collection():
-    return pystac.Collection.from_file(
+    return pystac.collection.Collection.from_file(
         str(TEST_DATA_FOLDER.joinpath(SENTINEL_STAC_COLLECTION))
     )
 

--- a/tests/data/test-product-eo.yml
+++ b/tests/data/test-product-eo.yml
@@ -1,0 +1,10 @@
+name: test_product_eo
+metadata_type: eo
+metadata:
+  product:
+    name: test_product_eo
+measurements:
+  - name: band
+    dtype: "float32"
+    nodata: .nan
+    units: "1"

--- a/tests/data/test-product-eo3.yml
+++ b/tests/data/test-product-eo3.yml
@@ -1,0 +1,10 @@
+name: test_product_eo3
+metadata_type: eo3
+metadata:
+  product:
+    name: test_product_eo3
+measurements:
+  - name: band
+    dtype: int16
+    nodata: -999
+    units: "1"

--- a/tests/test_dc_load.py
+++ b/tests/test_dc_load.py
@@ -69,6 +69,16 @@ def test_stac_load_smoketest(sentinel_stac_ms_with_raster_ext: pystac.Item):
     # expect product cache to contain 1 product
     assert len(product_cache) == 1
 
+    patch_url = MagicMock(return_value="https://example.com/f.tif")
+    zz = stac_load(
+        [item],
+        patch_url=patch_url,
+        stac_cfg={"*": {"warnings": "ignore"}},
+        product_cache=product_cache,
+        **params,
+    )
+    assert patch_url.call_count == len(zz.data_vars)
+
     yy = stac_load(
         [item], ["nir"], like=xx, chunks={}, stac_cfg={"*": {"warnings": "ignore"}}
     )

--- a/tests/test_dc_load.py
+++ b/tests/test_dc_load.py
@@ -2,6 +2,7 @@ from copy import deepcopy
 from unittest.mock import MagicMock
 
 import pystac
+import pystac.item
 import pytest
 from datacube.model import Dataset
 from pyproj.crs.crs import CRS
@@ -11,7 +12,7 @@ from odc.stac._load import most_common_crs
 
 
 def test_dc_load_smoketest(sentinel_stac_ms):
-    item = pystac.Item.from_dict(sentinel_stac_ms)
+    item = pystac.item.Item.from_dict(sentinel_stac_ms)
     with pytest.warns(UserWarning, match="`rededge`"):
         (ds,) = stac2ds([item], {})
 
@@ -35,7 +36,7 @@ def test_dc_load_smoketest(sentinel_stac_ms):
     assert xx.nir.geobox == yy.SCL.geobox
 
 
-def test_stac_load_smoketest(sentinel_stac_ms_with_raster_ext: pystac.Item):
+def test_stac_load_smoketest(sentinel_stac_ms_with_raster_ext: pystac.item.Item):
     item = sentinel_stac_ms_with_raster_ext.clone()
 
     params = dict(crs="EPSG:3857", resolution=100, align=0, chunks={})
@@ -105,14 +106,14 @@ def test_stac_load_smoketest(sentinel_stac_ms_with_raster_ext: pystac.Item):
 
     # test bbox overlaping with lon/lat
     with pytest.raises(ValueError):
-        stac_load([item], ["nir"], bbox=[0, 0, 1, 1], lon=(0, 1), lat=(0, 1), chunks={})
+        stac_load([item], ["nir"], bbox=(0, 0, 1, 1), lon=(0, 1), lat=(0, 1), chunks={})
 
     # test bbox overlaping with x/y
     with pytest.raises(ValueError):
         stac_load(
             [item],
             ["nir"],
-            bbox=[0, 0, 1, 1],
+            bbox=(0, 0, 1, 1),
             x=(0, 1000),
             y=(0, 1000),
             chunks={},

--- a/tests/test_index_tools.py
+++ b/tests/test_index_tools.py
@@ -1,7 +1,9 @@
+import datetime
 import pytest
 from datacube.utils import geometry as geom
 
 from odc.index._grouper import group_by_nothing, key2num, mid_longitude, solar_offset
+from odc.index._index import month_range, season_range
 
 
 @pytest.mark.parametrize("lon,lat", [(0, 10), (100, -10), (-120, 30)])
@@ -52,3 +54,21 @@ def test_grouper(s2_dataset):
     assert xx.values[0] == (s2_dataset,)
     assert xx.uuid.values[1] == s2_dataset.id
     assert xx.uuid.values[1] == s2_dataset.id
+
+
+def test_month_range():
+    m1, m2 = month_range(2019, 1, 3)
+    assert m1.year == 2019
+    assert m2.year == 2019
+    assert m1.month == 1 and m2.month == 3
+
+    m1, m2 = month_range(2019, 12, 3)
+    assert m1 == datetime.datetime(2019, 12, 1)
+    assert m2 == datetime.datetime(2020, 2, 29, 23, 59, 59, 999999)
+
+    assert month_range(2018, 12, 4) == month_range(2019, -1, 4)
+
+    assert season_range(2019, "djf") == month_range(2019, -1, 3)
+    assert season_range(2019, "mam") == month_range(2019, 3, 3)
+    assert season_range(2002, "jja") == month_range(2002, 6, 3)
+    assert season_range(2000, "son") == month_range(2000, 9, 3)

--- a/tests/test_index_tools.py
+++ b/tests/test_index_tools.py
@@ -1,0 +1,54 @@
+import pytest
+from datacube.utils import geometry as geom
+
+from odc.index._grouper import group_by_nothing, key2num, mid_longitude, solar_offset
+
+
+@pytest.mark.parametrize("lon,lat", [(0, 10), (100, -10), (-120, 30)])
+def test_mid_lon(lon, lat):
+    r = 0.1
+    rect = geom.box(lon - r, lat - r, lon + r, lat + r, "epsg:4326")
+    assert rect.centroid.coords[0] == pytest.approx((lon, lat))
+
+    assert mid_longitude(rect) == pytest.approx(lon)
+    assert mid_longitude(rect.to_crs("epsg:3857")) == pytest.approx(lon)
+
+    offset = solar_offset(rect, "h")
+    assert offset.seconds % (60 * 60) == 0
+
+    offset_sec = solar_offset(rect, "s")
+    assert abs((offset - offset_sec).seconds) <= 60 * 60
+
+
+@pytest.mark.parametrize(
+    "input,expect",
+    [
+        ("ABAAC", [0, 1, 0, 0, 2]),
+        ("B", [0]),
+        ([1, 1, 1], [0, 0, 0]),
+        ("ABCC", [0, 1, 2, 2]),
+    ],
+)
+def test_key2num(input, expect):
+    rr = list(key2num(input))
+    assert rr == expect
+
+    reverse = {}
+    rr = list(key2num(input, reverse))
+    assert rr == expect
+    assert set(reverse.keys()) == set(range(len(set(input))))
+    assert set(reverse.values()) == set(input)
+    # first entry always gets an index of 0
+    assert reverse[0] == input[0]
+
+
+def test_grouper(s2_dataset):
+    xx = group_by_nothing([s2_dataset])
+    assert xx.values[0] == (s2_dataset,)
+    assert xx.uuid.values[0] == s2_dataset.id
+
+    xx = group_by_nothing([s2_dataset, s2_dataset], solar_offset(s2_dataset.extent))
+    assert xx.values[0] == (s2_dataset,)
+    assert xx.values[0] == (s2_dataset,)
+    assert xx.uuid.values[1] == s2_dataset.id
+    assert xx.uuid.values[1] == s2_dataset.id

--- a/tests/test_index_tools.py
+++ b/tests/test_index_tools.py
@@ -1,9 +1,18 @@
 import datetime
-import pytest
-from datacube.utils import geometry as geom
+import json
+from unittest.mock import MagicMock
 
+import pytest
+import yaml
+from datacube.utils import geometry as geom
 from odc.index._grouper import group_by_nothing, key2num, mid_longitude, solar_offset
-from odc.index._index import month_range, season_range
+from odc.index._index import (
+    month_range,
+    parse_doc_stream,
+    season_range,
+    time_range,
+    product_from_yaml,
+)
 
 
 @pytest.mark.parametrize("lon,lat", [(0, 10), (100, -10), (-120, 30)])
@@ -72,3 +81,69 @@ def test_month_range():
     assert season_range(2019, "mam") == month_range(2019, 3, 3)
     assert season_range(2002, "jja") == month_range(2002, 6, 3)
     assert season_range(2000, "son") == month_range(2000, 9, 3)
+
+    with pytest.raises(ValueError):
+        season_range(2000, "ham")
+
+
+@pytest.mark.parametrize(
+    "t1, t2",
+    [
+        ("2020-01-17", "2020-03-19"),
+        ("2020-04-17", "2020-04-19"),
+        ("2020-02-01T13:08:01", "2020-09-03T00:33:46.103"),
+        ("2000-01-23", "2001-01-19"),
+    ],
+)
+def test_time_range(t1, t2):
+    t1, t2 = map(datetime.datetime.fromisoformat, (t1, t2))
+    tt = list(time_range(t1, t2))
+
+    assert tt[0][0] == t1
+    assert tt[-1][-1] == t2
+
+    if len(tt) == 1:
+        assert tt[0] == (t1, t2)
+
+    t_prev = tt[0][-1]
+    for t1, t2 in tt[1:]:
+        assert t1 > t_prev
+        assert (t1 - t_prev).seconds < 1
+        t_prev = t2
+
+
+def test_parse_doc_stream():
+    sample_data = {"a": 10, "b": [1]}
+    _json = json.dumps(sample_data)
+    _yaml = yaml.dump(sample_data)
+    data = [
+        ("http://example.com/foo.json", _json),
+        ("file:///blah.yml", _yaml),
+        ("s3://bu/f.json", "!!not a valid json!!"),
+    ]
+    _docs = list(parse_doc_stream(iter(data)))
+    assert len(_docs) == 3
+    assert _docs[0] == (data[0][0], sample_data)
+    assert _docs[1] == (data[1][0], sample_data)
+    assert _docs[2] == (data[2][0], None)
+
+    on_error = MagicMock()
+    transform = lambda d: dict(**d, seen=True)
+    _docs = list(parse_doc_stream(iter(data), transform=transform, on_error=on_error))
+    assert len(_docs) == 3
+    assert _docs[0][1] is not None
+    assert _docs[1][1] is not None
+    assert _docs[2][1] is None
+    assert _docs[0][1]["seen"]
+    assert _docs[1][1]["seen"]
+    assert on_error.call_count == 1
+
+
+def test_product_from_yaml(test_data_dir):
+    p = product_from_yaml(str(test_data_dir / "test-product-eo3.yml"))
+    assert p.name == "test_product_eo3"
+    assert p.metadata_type.name == "eo3"
+
+    p = product_from_yaml(str(test_data_dir / "test-product-eo.yml"))
+    assert p.name == "test_product_eo"
+    assert p.metadata_type.name == "eo"

--- a/tests/test_utm.py
+++ b/tests/test_utm.py
@@ -1,0 +1,55 @@
+"""Tests for UTM utilities in odc.index._utm."""
+
+import pytest
+
+from odc.index._utm import mk_utm_gs, utm_region_code, utm_tile_dss, utm_zone_to_epsg
+
+
+@pytest.mark.parametrize(
+    "zone,epsg",
+    [("56S", 32756), ("55N", 32655), ("01S", 32701), ("01N", 32601), ("60S", 32760)],
+)
+def test_zone_to_epsg(zone, epsg):
+    assert utm_zone_to_epsg(zone) == epsg
+    assert utm_region_code(epsg) == zone
+    assert utm_region_code(epsg, (1, 3)) == f"{zone}_01_03"
+    assert utm_region_code((epsg, 1, 4)) == f"{zone}_01_04"
+
+
+@pytest.mark.parametrize("zone", ["", "10", "61S", "100N", "XXS"])
+def test_utm_unhappy_paths(zone):
+    with pytest.raises(ValueError):
+        utm_zone_to_epsg(zone)
+
+
+@pytest.mark.parametrize("epsg", [4326, 3857, 32661, 32761])
+def test_utm_region_code_unhappy_paths(epsg):
+    with pytest.raises(ValueError):
+        utm_region_code(epsg)
+
+
+def test_mk_utm_gs():
+    gs = mk_utm_gs(32756, (-10, 10), 297)
+    assert gs.resolution == (-10, 10)
+    assert gs.crs.epsg == 32756
+    assert gs.tile_geobox((0, 0)).shape == (297, 297)
+    assert gs.tile_size == (2970, 2970)
+
+    gs = mk_utm_gs(32656, 10, 297)
+    assert gs.resolution == (-10, 10)
+    assert gs.crs.epsg == 32656
+    assert gs.tile_geobox((0, 0)).shape == (297, 297)
+    assert gs.tile_size == (2970, 2970)
+
+
+def test_tile_dss_smoke_test(s2_dataset):
+    tiles = utm_tile_dss([s2_dataset] * 3, resolution=10, pixels_per_cell=2000)
+    assert len(tiles) > 0
+
+    for tile in tiles:
+        assert len(tile.region) == 3
+        assert tile.region[0] == s2_dataset.crs.epsg
+        assert len(tile.dss) == 3
+        assert tile.grid_spec.tile_geobox(tile.region[1:]) == tile.geobox
+        for ds in tile.dss:
+            assert ds.extent.intersects(tile.geobox.extent)


### PR DESCRIPTION
For the most part fixes for `pydocstyle`

- Ensure first line ends on `.` and is short
- Ensure single line docs are single line

MYPY:

- couple of places where None could happen didn't check for None.
- using full path for `pystac.{item,collection,errors}` rather than
  lazy imports from `pystac.`

Errors:
- fixes error in utility function that converts season by name into a time interval

