### PR TITLE
Updating documentation notebook infra

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,7 +17,7 @@ sys.path.insert(0, os.path.abspath(".."))
 from odc.stac._version import __version__ as _odc_stac_version
 
 
-def ensure_notebooks(git_url, dst_folder):
+def ensure_notebooks(git_url, branch, dst_folder):
     """
     Download pre-rendered notebooks from a gist for now
     """
@@ -29,11 +29,11 @@ def ensure_notebooks(git_url, dst_folder):
         return
 
     print(f"Cloning: {git_url} to {dst_folder}")
-    os.system(f"git clone --depth=1 '{git_url}' '{dst_folder}'")
+    os.system(f"git clone --depth=1 '{git_url}' -b '{branch}' '{dst_folder}'")
 
 
 ensure_notebooks(
-    "https://gist.github.com/4845c9f33509650e4a7a6e751d377fb6.git", "notebooks"
+    "https://github.com/opendatacube/odc-stac.git", "nb-renders", "notebooks"
 )
 
 # -- Project information -----------------------------------------------------

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -7,5 +7,5 @@ Example Notebooks
 .. toctree::
    :maxdepth: 2
 
-   notebooks/odc-stac-load-e84-aws
-   notebooks/odc-stac-load-example
+   notebooks/stac-load-e84-aws
+   notebooks/stac-load-S2-ms

--- a/notebooks/render-nb.sh
+++ b/notebooks/render-nb.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+src=$1
+dst=${2:-${src%%.py}.ipynb}
+
+echo "$src -> $dst"
+
+jupytext $src --to ipynb -o - \
+  | jupyter nbconvert \
+      --stdin \
+      --to notebook \
+      --stdout \
+      --ExecutePreprocessor.store_widget_state=True \
+      --execute > "${dst}"


### PR DESCRIPTION
- Using detached branch in this repo for pre-rendered notebooks instead of gist repo

This is probably not a permanent solution as this does increase checkout size even though the branch is detached, it's not too bad right now but if we want to keep history of notebook renders that can quickly blow up repo size to uncomfortable levels. We can of course keep `nb-renders` branch with just the latest renders by using `--amend` and `push --force-with-lease`...

This will have to do for now, notebooks on the doc site need updating so I'll go ahead with this for now