### PR TITLE
Changing doc building to re-build notebooks as needed

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -382,6 +382,7 @@ jobs:
 
     - name: Deploy to Netlify
       id: netlify
+      if: github.event_name == 'pull_request'
       uses: nwtgck/actions-netlify@v1.0
       with:
         production-branch: 'main'
@@ -393,6 +394,7 @@ jobs:
 
     - name: Print Notice
       uses: actions/github-script@v5
+      if: github.event_name == 'pull_request'
       env:
         NETLIFY_URL: ${{ steps.netlify.outputs.deploy-url }}
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -388,6 +388,11 @@ jobs:
         production-branch: 'main'
         publish-dir: 'docs/_build/html'
         deploy-message: "Deploy from GitHub Actions"
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        enable-pull-request-comment: true
+        overwrites-pull-request-comment: true
+        enable-commit-comment: false
+
       env:
         NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
         NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -17,23 +17,73 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Config
+      id: cfg
+      run: |
+        find notebooks/ -maxdepth 1 -name '*.py' -type f | sort -f -d
+
+        nb_dir="docs/notebooks"
+        nb_hash=$(find notebooks/ -maxdepth 1 -name '*.py' -type f | sort -f -d | xargs cat | sha256sum | cut -b -16)
+        echo "Notebooks hash: ${nb_hash}"
+        echo "::set-output name=nb-dir::${nb_dir}"
+        echo "::set-output name=nb-hash::${nb_hash}"
+        echo "::set-output name=nb-archive::odc-stac-notebooks-${nb_hash}.tar.gz"
+
+    - uses: actions/cache@v2
+      id: nb_cache
+      with:
+        path: ${{ steps.cfg.outputs.nb-dir }}
+        key: docs-notebooks-${{ hashFiles('notebooks/*.py') }}
+
     - name: Pull Docker
+      if: steps.nb_cache.outputs.cache-hit != 'true'
       run: |
         docker pull $DKR
 
     - name: Run Notebooks
+      if: steps.nb_cache.outputs.cache-hit != 'true'
       run: |
-        mkdir -p rendered
+        nb_dir="${{ steps.cfg.outputs.nb-dir }}"
+
+        mkdir -p $nb_dir
         for src in $(find notebooks -type f -maxdepth 1 -name '*py'); do
-           dst="rendered/$(basename ${src%%.py}.ipynb)"
+           dst="${nb_dir}/$(basename ${src%%.py}.ipynb)"
            echo "$src -> $dst"
            docker run -i --entrypoint ./binder/render-nb-pipe.sh $DKR <$src >$dst
         done
-        ls -lh rendered/
+        ls -lh ${nb_dir}/
+
+    - name: Package Notebooks
+      run: |
+        nb_dir="${{ steps.cfg.outputs.nb-dir }}"
+        nb_hash="${{ steps.cfg.outputs.nb-hash }}"
+        nb_archive="${{ steps.cfg.outputs.nb-archive }}"
+        echo "DIR: ${nb_dir}"
+        echo "NB hash: $nb_hash"
+        echo "Archive: $nb_archive"
+
+        (cd $nb_dir && tar cvz .) > "${nb_archive}"
+        ls -lh "${nb_archive}"
+        tar tzf "${nb_archive}"
+
+    - name: Upload to S3
+      run: |
+        nb_archive="${{ steps.cfg.outputs.nb-archive }}"
+        echo "Using Keys: ...${AWS_ACCESS_KEY_ID:(-4)}/...${AWS_SECRET_ACCESS_KEY:(-4)}"
+        echo "Testing permissions"
+        aws s3 ls "${S3_DST}/" || true
+        aws s3 cp "${nb_archive}" "${S3_DST}/${nb_archive}"
+
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY }}
+        AWS_DEFAULT_REGION: 'ap-southeast-2'
+        AWS_REGION: 'ap-southeast-2'
+        S3_DST: 's3://datacube-core-deployment/odc-stac/nb'
 
     - name: Upload results (artifact)
       uses: actions/upload-artifact@v2
       with:
         name: rendered-notebooks
-        path: rendered/
+        path: docs/notebooks
         if-no-files-found: error

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -11,3 +11,25 @@ these `.py` files.
 To create a new one, start with a notebook file (`.ipynb`) then use "Pair
 Notebook with percent Script" command (type `Ctr-Shift-C` when editing notebook,
 then start typing "percent" to fuzzy find the command)
+
+
+## Rendered Notebooks
+
+Notebooks are executed by github action and results are uploaded to:
+
+```
+s3://datacube-core-deployment/odc-stac/nb/odc-stac-notebooks-{nb_hash}.tar.gz
+https://packages.dea.ga.gov.au/odc-stac/nb/odc-stac-notebooks-{nb_hash}.tar.gz
+```
+
+Where `{nb_hash}` is a 16 character hash computed from the content of `noteboos/*.py`
+
+```
+find notebooks/ -maxdepth 1 -name '*.py' -type f | \ 
+  sort -f -d | xargs cat | sha256sum | cut -b -16
+```
+
+By the time changes are merged into `develop` branch there should be
+pre-rendered notebook archive accessible without authentication via https.
+Building documentation on read the docs site will use that archive rather than
+attempting to run notebooks directly.


### PR DESCRIPTION
- Rather than storing rendered notebooks in the repo store them on S3 (same place as dev packages)
- Use hash based on content of `notebooks/*py` files to determine location of the cache file
