### PR TITLE
Notebook examples, use less of odc.ui things

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -390,7 +390,6 @@ jobs:
         deploy-message: "Deploy from GitHub Actions"
         github-token: ${{ secrets.GITHUB_TOKEN }}
         enable-pull-request-comment: true
-        overwrites-pull-request-comment: true
         enable-commit-comment: false
 
       env:

--- a/binder/start
+++ b/binder/start
@@ -2,12 +2,8 @@
 
 # This runs when binder is launched
 
-# Replace DASK_DASHBOARD_URL with the proxy location
-#sed -i -e "s|DASK_DASHBOARD_URL|${JUPYTERHUB_BASE_URL}user/${JUPYTERHUB_USER}/proxy/8787|g" binder/jupyterlab-workspace.json
-# Import the workspace
-# jupyter lab workspaces import binder/jupyterlab-workspace.json
-
 date > .startup.log
+jupytext -k python3 $HOME/notebooks/*py
 jupytext -s $HOME/notebooks/*{py,md}
 
 sed -i -e "s|__JUPYTERHUB_USER__|${JUPYTERHUB_USER}|g" $HOME/.config/dask/dask.yaml

--- a/docs/_static/xr-fixes.css
+++ b/docs/_static/xr-fixes.css
@@ -11,19 +11,19 @@
 
 .rst-content dl.xr-attrs dt,
 .rst-content dl.xr-attrs dd {
-	  margin: 0px 0;
-	  font-size: inherit;
-	  background: inherit;
-	  color: inherit;
-	  border-top: none;
-	  padding: 0px;
+	  margin: 0px 0 !important;
+	  font-size: inherit !important;
+	  background: inherit !important;
+	  color: inherit !important;
+	  border-top: none !important;
+	  padding: 0px !important;
 }
 
 .rst-content dl.xr-attrs dt {
-	  font-weight: normal;
-	  grid-column: 1;
+	  font-weight: normal !important;
+	  grid-column: 1 !important;
 }
 
 .rst-content dl.xr-attrs dd {
-	  grid-column: 2;
+	  grid-column: 2 !important;
 }

--- a/docs/_static/xr-fixes.css
+++ b/docs/_static/xr-fixes.css
@@ -1,0 +1,29 @@
+/* xarray widget tweaks
+
+   Some styles from default theme interfere, so define more specific rules to
+   override
+*/
+
+.rst-content section ul.xr-var-list li>* {
+	  margin-top: 0px;
+	  margin-bottom: 0px
+}
+
+.rst-content dl.xr-attrs dt,
+.rst-content dl.xr-attrs dd {
+	  margin: 0px 0;
+	  font-size: inherit;
+	  background: inherit;
+	  color: inherit;
+	  border-top: none;
+	  padding: 0px;
+}
+
+.rst-content dl.xr-attrs dt {
+	  font-weight: normal;
+	  grid-column: 1;
+}
+
+.rst-content dl.xr-attrs dd {
+	  grid-column: 2;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -144,3 +144,5 @@ html_show_sphinx = False
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
+
+html_css_files = ["xr-fixes.css"]

--- a/notebooks/stac-load-e84-aws.py
+++ b/notebooks/stac-load-e84-aws.py
@@ -21,16 +21,14 @@
 # %%
 import odc.ui
 import yaml
-from IPython.display import display
+from ipyleaflet import FullScreenControl, GeoJSON, LayersControl, Map, Rectangle
+from IPython.display import Image, display
 from odc.algo import to_rgba
-from pystac_client import Client
-
 from odc.stac import stac_load
+from pystac_client import Client
 
 # %%
 cfg = """---
-"*":
-  warnings: ignore # Disable warnings about duplicate common names
 sentinel-s2-l2a-cogs:
   assets:
     '*':
@@ -49,6 +47,8 @@ sentinel-s2-l2a-cogs:
     red: B04
     green: B03
     blue: B02
+"*":
+  warnings: ignore # Disable warnings about duplicate common names
 """
 cfg = yaml.load(cfg, Loader=yaml.SafeLoader)
 
@@ -61,22 +61,76 @@ catalog = Client.open("https://earth-search.aws.element84.com/v0")
 km2deg = 1.0 / 111
 x, y = (113.887, -25.843)  # Center point of a query
 r = 100 * km2deg
+bbox = (x - r, y - r, x + r, y + r)
 
 query = catalog.search(
-    collections=["sentinel-s2-l2a-cogs"],
-    datetime="2021-09-16",
-    limit=10,
-    bbox=(x - r, y - r, x + r, y + r),
+    collections=["sentinel-s2-l2a-cogs"], datetime="2021-09-16", limit=100, bbox=bbox
 )
 
 items = list(query.get_items())
 print(f"Found: {len(items):d} datasets")
 
 # %% [markdown]
+# ## Plot STAC Items on a Map
+
+# %%
+query_rectangle = Rectangle(
+    bounds=(
+        bbox[:2][::-1],
+        bbox[2:][::-1],
+    ),  # IPyleaflet expects ((lat1, lon1), (lat2, lon2))
+    fill=False,
+    weight=3,
+    opacity=0.7,
+    color="olive",
+    name="Query",
+)
+
+# Convert STAC items into a GeoJSON FeatureCollection
+stac_json = {
+    "type": "FeatureCollection",
+    "features": [item.to_dict() for item in items],
+}
+
+footprint_style = dict(
+    fillColor="black",
+    fillOpacity=0.0,
+    weight=1,
+    opacity=0.6,
+    color="magenta",
+    dashArray=1,
+)
+hover_style = dict(
+    weight=4,
+    opacity=1,
+    color="tomato",
+)
+
+# Make GeoJSON layer with styles
+stac_layer = GeoJSON(
+    data=stac_json,
+    style=footprint_style,
+    hover_style=hover_style,
+    name="STAC",
+)
+
+# Make a leaflet.Map object
+map1 = Map(scroll_wheel_zoom=True, center=(y, x), zoom=5)
+map1.layout.height = "300px"
+map1.layout.width = "300px"
+
+# Plot query rectangle
+map1.add_layer(query_rectangle)
+# Plot footprints on top
+map1.add_layer(stac_layer)
+
+display(map1)
+
+# %% [markdown]
 # ## Construct Dask Dataset
 #
 # Note that even though there are 9 STAC Items on input, there is only one
-# timeslice on output. This is because of `groupy="solar_day"`. With that
+# timeslice on output. This is because of `groupby="solar_day"`. With that
 # setting `stac_load` will place all items that occured on the same day (as
 # adjusted for the timezone) into one image plane.
 
@@ -107,26 +161,56 @@ _rgba = rgba.compute()
 # %% [markdown]
 # ## Display Image on a map
 
-# %% tags=[]
-from ipyleaflet import FullScreenControl, ImageOverlay, LayersControl, Map
-
+# %%
 # This compresses image with png and packs it into `data` url
 # it then computes Image bounds and return `ipyleaflet.ImageOverlay`
 ovr = odc.ui.mk_image_overlay(_rgba)
 
 # Make a leaflet.Map object
 lon, lat = rgba.geobox.geographic_extent.centroid.coords[0]
-_map = Map(scroll_wheel_zoom=True, center=(lat, lon), zoom=8)
-
-# Make a leaflet.Map object
-_map.layout.height = "600px"
-_map.add_control(FullScreenControl())
-_map.add_control(LayersControl())
+map2 = Map(scroll_wheel_zoom=True, center=(lat, lon), zoom=8)
+map2.layout.height = "600px"
+map2.add_control(FullScreenControl())
+map2.add_control(LayersControl())
 
 # Add Image overlay
-_map.add_layer(ovr)
+map2.add_layer(ovr)
 
-display(_map)
+# Plot footprints on top
+map2.add_layer(query_rectangle)
+map2.add_layer(stac_layer)
+
+display(map2)
+
+# %% [markdown]
+# ## Load with bounding box
+#
+# As you can see `stac_load` returned all the data covered by STAC items
+# returned from the query. This happens by default as `stac_load` has no way of
+# knowing what your query was. But it is possible to control what region is
+# loaded. There are several mechanisms available, but probably simplest one is
+# to use `bbox=` parameter (compatible with `stac_client`).
+#
+# Let's load a small region at native resolution to demonstrate.
+
+# %%
+r = 6 * km2deg
+small_bbox = (x - r, y - r, x + r, y + r)
+
+yy = stac_load(
+    items,
+    bands=("red", "green", "blue"),
+    crs=crs,
+    resolution=10,
+    chunks={},  # <-- use Dask
+    groupby="solar_day",
+    stac_cfg=cfg,
+    bbox=small_bbox,
+)
+im_small = to_rgba(yy, clamp=(1, 3000)).compute()
+
+# %%
+display(Image(data=odc.ui.to_jpeg_data(im_small.isel(time=0).data, quality=80)))
 
 # %% [markdown]
 # --------------------------------------------------------------

--- a/notebooks/stac-load-e84-aws.py
+++ b/notebooks/stac-load-e84-aws.py
@@ -115,16 +115,16 @@ from ipyleaflet import FullScreenControl, ImageOverlay, LayersControl, Map
 ovr = odc.ui.mk_image_overlay(_rgba)
 
 # Make a leaflet.Map object
-_map = Map(scroll_wheel_zoom=True, zoom=1)
+lon, lat = rgba.geobox.geographic_extent.centroid.coords[0]
+_map = Map(scroll_wheel_zoom=True, center=(lat, lon), zoom=8)
+
+# Make a leaflet.Map object
 _map.layout.height = "600px"
 _map.add_control(FullScreenControl())
 _map.add_control(LayersControl())
 
 # Add Image overlay
 _map.add_layer(ovr)
-
-# Zoom to area of interest
-_map.fit_bounds(ovr.bounds[::-1])  # need to flip Y axis
 
 display(_map)
 

--- a/notebooks/stac-load-e84-aws.py
+++ b/notebooks/stac-load-e84-aws.py
@@ -25,7 +25,7 @@ from IPython.display import display
 from odc.algo import to_rgba
 from pystac_client import Client
 
-from odc.stac import stac2ds, stac_load
+from odc.stac import stac_load
 
 # %%
 cfg = """---
@@ -107,11 +107,25 @@ _rgba = rgba.compute()
 # %% [markdown]
 # ## Display Image on a map
 
-# %%
-dss = list(stac2ds(items, cfg))
-_map = odc.ui.show_datasets(dss, style={"fillOpacity": 0.1}, scroll_wheel_zoom=True)
+# %% tags=[]
+from ipyleaflet import FullScreenControl, ImageOverlay, LayersControl, Map
+
+# This compresses image with png and packs it into `data` url
+# it then computes Image bounds and return `ipyleaflet.ImageOverlay`
 ovr = odc.ui.mk_image_overlay(_rgba)
+
+# Make a leaflet.Map object
+_map = Map(scroll_wheel_zoom=True, zoom=1)
+_map.layout.height = "600px"
+_map.add_control(FullScreenControl())
+_map.add_control(LayersControl())
+
+# Add Image overlay
 _map.add_layer(ovr)
+
+# Zoom to area of interest
+_map.fit_bounds(ovr.bounds[::-1])  # need to flip Y axis
+
 display(_map)
 
 # %% [markdown]


### PR DESCRIPTION
Testing how well new way of updating notebooks works.

There should be a netlify link posted that allows to review documentation changes before they make it to read the docs.

## Notebook changes

Significant improvements in "load data from AWS Sentinel2 collection".

- Don't sure `odc.ui.show_datasets` instead construct `ipyleaflet.Map` manually
- Plot STAC footprints and query rectangle
- Demonstrate how to load smaller region
- Fix CSS problems when displaying xarray widget state

To review changes see here:
https://618a4f6414a45b24dd03d7fb--odc-stac-docs.netlify.app/notebooks/stac-load-e84-aws.html


