### PR TITLE
Switch example notebook to folium and geopandas

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,9 +11,9 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
 import os
+import subprocess
 import sys
 from pathlib import Path
-import subprocess
 
 sys.path.insert(0, os.path.abspath(".."))
 from odc.stac._version import __version__ as _odc_stac_version

--- a/notebooks/render-html.sh
+++ b/notebooks/render-html.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+src=$1
+dst=${2:-${src%%.py}.html}
+
+echo "$src -> $dst"
+
+jupytext $src --set-kernel "python3" --to ipynb -o - \
+  | jupyter nbconvert \
+      --stdin \
+      --to html \
+      --stdout \
+      --ExecutePreprocessor.store_widget_state=True \
+      --execute > "${dst}"

--- a/notebooks/stac-load-e84-aws.py
+++ b/notebooks/stac-load-e84-aws.py
@@ -30,8 +30,9 @@ import yaml
 from branca.element import Figure
 from IPython.display import HTML, display
 from odc.algo import to_rgba
-from odc.stac import stac_load
 from pystac_client import Client
+
+from odc.stac import stac_load
 
 
 # %%

--- a/odc/stac/_dcload.py
+++ b/odc/stac/_dcload.py
@@ -22,10 +22,10 @@ def _geojson_to_shapely(xx: Any) -> shapely.geometry.base.BaseGeometry:
         features = xx.get("features", [])
         if len(features) == 1:
             return shapely.geometry.shape(features[0]["geometry"])
-        else:
-            return shapely.geometry.GeometryCollection(
-                [shapely.geometry.shape(feature["geometry"]) for feature in features]
-            )
+
+        return shapely.geometry.GeometryCollection(
+            [shapely.geometry.shape(feature["geometry"]) for feature in features]
+        )
     elif _type == "feature":
         return shapely.geometry.shape(xx["geometry"])
 
@@ -44,6 +44,9 @@ def _normalize_geometry(xx: Any) -> datacube.utils.geometry.Geometry:
 
     # GeoPandas
     _geo = getattr(xx, "__geo_interface__", None)
+    if _geo is None:
+        raise ValueError("Can't interpret value as geometry")
+
     _crs = getattr(xx, "crs", "epsg:4326")
     return datacube.utils.geometry.Geometry(_geojson_to_shapely(_geo), _crs)
 

--- a/odc/stac/_dcload.py
+++ b/odc/stac/_dcload.py
@@ -26,7 +26,8 @@ def _geojson_to_shapely(xx: Any) -> shapely.geometry.base.BaseGeometry:
         return shapely.geometry.GeometryCollection(
             [shapely.geometry.shape(feature["geometry"]) for feature in features]
         )
-    elif _type == "feature":
+
+    if _type == "feature":
         return shapely.geometry.shape(xx["geometry"])
 
     return shapely.geometry.shape(xx)

--- a/odc/stac/_load.py
+++ b/odc/stac/_load.py
@@ -140,7 +140,7 @@ def load(
     y: Optional[Tuple[float, float]] = None,
     align: Optional[Union[float, int, Tuple[float, float]]] = None,
     like: Optional[Any] = None,
-    geopolygon: Optional[datacube.utils.geometry.Geometry] = None,
+    geopolygon: Optional[Any] = None,
     # stac related
     stac_cfg: Optional[ConversionConfig] = None,
     patch_url: Optional[Callable[[str], str]] = None,
@@ -259,6 +259,13 @@ def load(
 
     :param like:
        Match output grid to the data loaded previously.
+
+    :param geopolygon:
+       Limit returned result to a bounding box of a given geometry. This could be an
+       instance of :class:`~datacube.utils.geometry.Geometry`, GeoJSON dictionary,
+       GeoPandas DataFrame, or any object implementing ``__geo_interface__``. We assume
+       ``EPSG:4326`` projection for dictionary and Shapely inputs. CRS information available
+       on GeoPandas inputs should be understood correctly.
 
     .. rubric:: STAC Related Options
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -115,3 +115,31 @@ def s2_dataset(sentinel_stac_ms_with_raster_ext):
         [sentinel_stac_ms_with_raster_ext], cfg={"*": {"warnings": "ignore"}}
     )
     yield ds
+
+
+@pytest.fixture
+def sample_geojson():
+    return {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {"name": "Kangaroo Island"},
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [
+                        [
+                            [136.351318359375, -35.78217070326606],
+                            [136.7303466796875, -36.16448788632062],
+                            [137.5323486328125, -36.16005298551352],
+                            [137.8179931640625, -35.933540642493114],
+                            [138.0816650390625, -36.05798104702501],
+                            [138.2025146484375, -35.74205383068035],
+                            [137.5653076171875, -35.46066995149529],
+                            [136.351318359375, -35.78217070326606],
+                        ]
+                    ],
+                },
+            }
+        ],
+    }

--- a/tests/test-env-py38.yml
+++ b/tests/test-env-py38.yml
@@ -27,6 +27,7 @@ dependencies:
   - mock
   - deepdiff
   - pystac-client >=0.2.0
+  - geopandas
 
   # for docs
   - sphinx

--- a/tests/test_dc_load.py
+++ b/tests/test_dc_load.py
@@ -241,3 +241,7 @@ def test_normalize_geometry(sample_geojson):
 
     with pytest.raises(ValueError):
         _normalize_geometry({})
+
+    # some object without __geo_interface__
+    with pytest.raises(ValueError):
+        _normalize_geometry(epsg4326)


### PR DESCRIPTION
- More rich display of STAC data using Geopandas
- Since geopandas uses folium, switch to folium
- Accept more types of `geopolygon=` parameter see #12,
- Closes #12 