### PR TITLE
Deal with STAC items that have only partial proj data

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ from datacube.utils import documents
 from odc.stac import stac2ds
 
 TEST_DATA_FOLDER: Path = Path(__file__).parent.joinpath("data")
+PARTIAL_PROJ_STAC: str = "only_crs_proj.json"
 GA_LANDSAT_STAC: str = "ga_ls8c_ard_3-1-0_088080_2020-05-25_final.stac-item.json"
 GA_LANDSAT_ODC: str = "ga_ls8c_ard_3-1-0_088080_2020-05-25_final.odc-metadata.yaml"
 SENTINEL_STAC_COLLECTION: str = "sentinel-2-l2a.collection.json"
@@ -32,6 +33,17 @@ LIDAR_STAC: str = "lidar_dem.json"
 @pytest.fixture(scope="session")
 def test_data_dir():
     return TEST_DATA_FOLDER
+
+
+@pytest.fixture
+def partial_proj_stac():
+    return pystac.item.Item.from_file(str(TEST_DATA_FOLDER.joinpath(PARTIAL_PROJ_STAC)))
+
+
+@pytest.fixture
+def no_bands_stac(partial_proj_stac):
+    partial_proj_stac.assets.clear()
+    return partial_proj_stac
 
 
 @pytest.fixture

--- a/tests/data/only_crs_proj.json
+++ b/tests/data/only_crs_proj.json
@@ -1,0 +1,210 @@
+{
+  "stac_version": "1.0.0",
+  "type": "Feature",
+  "id": "3af1acae-0255-4762-b2b2-f26034cf3ce8",
+  "properties": {
+    "title": "LS_FC_PC_3577_-14_-26_20190101",
+    "platform": "landsat-5,landsat-7,landsat-8",
+    "instruments": [
+      "tm,etm+,oli"
+    ],
+    "created": "2020-03-10T05:35:24.063151Z",
+    "proj:epsg": 4326,
+    "datetime": "2019-01-01T00:00:00Z",
+    "cubedash:region_code": "-14_-26"
+  },
+  "geometry": {
+    "type": "Polygon",
+    "coordinates": [
+      [
+        [
+          118.22240593999766,
+          -22.699975944231888
+        ],
+        [
+          118.24427397418242,
+          -22.515645780963876
+        ],
+        [
+          119.22003537123638,
+          -22.60842512232027
+        ],
+        [
+          119.12126684085257,
+          -23.49827058643962
+        ],
+        [
+          118.13807838381156,
+          -23.404891555616906
+        ],
+        [
+          118.22240593999766,
+          -22.699975944231888
+        ]
+      ]
+    ]
+  },
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://explorer-aws.dea.ga.gov.au/stac/collections/fc_percentile_albers_annual/items/3af1acae-0255-4762-b2b2-f26034cf3ce8",
+      "type": "application/json"
+    },
+    {
+      "rel": "odc_yaml",
+      "href": "https://explorer-aws.dea.ga.gov.au/dataset/3af1acae-0255-4762-b2b2-f26034cf3ce8.odc-metadata.yaml",
+      "type": "text/yaml",
+      "title": "ODC Dataset YAML"
+    },
+    {
+      "rel": "collection",
+      "href": "https://explorer-aws.dea.ga.gov.au/stac/collections/fc_percentile_albers_annual"
+    },
+    {
+      "rel": "product_overview",
+      "href": "https://explorer-aws.dea.ga.gov.au/product/fc_percentile_albers_annual",
+      "type": "text/html",
+      "title": "ODC Product Overview"
+    },
+    {
+      "rel": "alternative",
+      "href": "https://explorer-aws.dea.ga.gov.au/dataset/3af1acae-0255-4762-b2b2-f26034cf3ce8",
+      "type": "text/html",
+      "title": "ODC Dataset Overview"
+    },
+    {
+      "rel": "root",
+      "href": "https://explorer-aws.dea.ga.gov.au/stac"
+    }
+  ],
+  "assets": {
+    "BS_PC_10": {
+      "href": "s3://dea-public-data/fractional-cover/fc-percentile/annual/v2.2.0/combined/x_-14/y_-26/2019/LS_FC_PC_3577_-14_-26_20190101_BS_PC_10.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "BS_PC_10",
+      "eo:bands": [
+        {
+          "name": "BS_PC_10"
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "BS_PC_50": {
+      "href": "s3://dea-public-data/fractional-cover/fc-percentile/annual/v2.2.0/combined/x_-14/y_-26/2019/LS_FC_PC_3577_-14_-26_20190101_BS_PC_50.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "BS_PC_50",
+      "eo:bands": [
+        {
+          "name": "BS_PC_50"
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "BS_PC_90": {
+      "href": "s3://dea-public-data/fractional-cover/fc-percentile/annual/v2.2.0/combined/x_-14/y_-26/2019/LS_FC_PC_3577_-14_-26_20190101_BS_PC_90.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "BS_PC_90",
+      "eo:bands": [
+        {
+          "name": "BS_PC_90"
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "PV_PC_10": {
+      "href": "s3://dea-public-data/fractional-cover/fc-percentile/annual/v2.2.0/combined/x_-14/y_-26/2019/LS_FC_PC_3577_-14_-26_20190101_PV_PC_10.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "PV_PC_10",
+      "eo:bands": [
+        {
+          "name": "PV_PC_10"
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "PV_PC_50": {
+      "href": "s3://dea-public-data/fractional-cover/fc-percentile/annual/v2.2.0/combined/x_-14/y_-26/2019/LS_FC_PC_3577_-14_-26_20190101_PV_PC_50.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "PV_PC_50",
+      "eo:bands": [
+        {
+          "name": "PV_PC_50"
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "PV_PC_90": {
+      "href": "s3://dea-public-data/fractional-cover/fc-percentile/annual/v2.2.0/combined/x_-14/y_-26/2019/LS_FC_PC_3577_-14_-26_20190101_PV_PC_90.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "PV_PC_90",
+      "eo:bands": [
+        {
+          "name": "PV_PC_90"
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "NPV_PC_10": {
+      "href": "s3://dea-public-data/fractional-cover/fc-percentile/annual/v2.2.0/combined/x_-14/y_-26/2019/LS_FC_PC_3577_-14_-26_20190101_NPV_PC_10.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "NPV_PC_10",
+      "eo:bands": [
+        {
+          "name": "NPV_PC_10"
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "NPV_PC_50": {
+      "href": "s3://dea-public-data/fractional-cover/fc-percentile/annual/v2.2.0/combined/x_-14/y_-26/2019/LS_FC_PC_3577_-14_-26_20190101_NPV_PC_50.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "NPV_PC_50",
+      "eo:bands": [
+        {
+          "name": "NPV_PC_50"
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "NPV_PC_90": {
+      "href": "s3://dea-public-data/fractional-cover/fc-percentile/annual/v2.2.0/combined/x_-14/y_-26/2019/LS_FC_PC_3577_-14_-26_20190101_NPV_PC_90.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "NPV_PC_90",
+      "eo:bands": [
+        {
+          "name": "NPV_PC_90"
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    }
+  },
+  "bbox": [
+    118.13807838381156,
+    -23.49827058643962,
+    119.22003537123638,
+    -22.515645780963876
+  ],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
+  ],
+  "collection": "fc_percentile_albers_annual"
+}

--- a/tests/test_stac_eo3.py
+++ b/tests/test_stac_eo3.py
@@ -190,7 +190,6 @@ def test_infer_product_item(sentinel_stac_ms: pystac.item.Item):
 
     with pytest.warns(UserWarning, match="Common name `rededge` is repeated, skipping"):
         product = infer_dc_product(item_no_collection)
-    print(product)
 
 
 def test_infer_product_raster_ext(sentinel_stac_ms_with_raster_ext: pystac.item.Item):
@@ -394,3 +393,13 @@ def test_issue_n6(usgs_landsat_stac_v1):
     }
     p = infer_dc_product(usgs_landsat_stac_v1)
     assert set(p.measurements) == expected_bands
+
+
+def test_partial_proj(partial_proj_stac):
+    (ds,) = list(stac2ds([partial_proj_stac]))
+    assert ds.metadata_doc["grids"]["default"]["shape"] == (1, 1)
+
+
+def test_noassets_case(no_bands_stac):
+    with pytest.raises(ValueError):
+        list(stac2ds([no_bands_stac]))


### PR DESCRIPTION
Before this change we assumed the following

- If an Item declares proj extension, then it includes shape/transform data
- And hence only bands with proj metadata set should be considered as valid

However it is possible that only CRS information is supplied on an Item, in
this case we would find no data bands at all and then fail in unexpected way.

The change here is to retain the same rule, but with a minor twist

- If there are any bands with proj data, take only those
- Else it is as if there were no proj extension data at all

This is a little bit sub-optimal, as it would be nice to propagate CRS
information from STAC to Dataset even when shape/transform information is missing.

Closes #19 