### PR TITLE
Chores

### DIFF
--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -23,7 +23,7 @@ jobs:
         find notebooks/ -maxdepth 1 -name '*.py' -type f | sort -f -d
 
         nb_dir="docs/notebooks"
-        nb_hash=$(find notebooks/ -maxdepth 1 -name '*.py' -type f | sort -f -d | xargs cat | sha256sum | cut -b -16)
+        nb_hash=$(python scripts/notebook_hash.py)
         echo "Notebooks hash: ${nb_hash}"
         echo "::set-output name=nb-dir::${nb_dir}"
         echo "::set-output name=nb-hash::${nb_hash}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,43 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- This CHANGELOG
+- requirements-dev.txt
+- Documentation
+- Upload built conda environment as an artifact
+- Notebook rendering to Github actions, including hash-based artifact checks
+
+### Changed
+
+- Moved publishing steps into separate workflows
+
+### Fixed
+
+- Typos in documentation
+
+## [v0.2.2] - 2021-10-25
+
+### Added
+
+- Binder launcher to README
+- Another USGS STAC example for Landsat SR
+- Documentation
+
+### Changed
+
+- Cleaned up test fixtures
+- Relaxed `is_raster_data` check
+- Force data band decision for explicitly configured bands
+- Moved constansts in to global scope
+
+## [v0.2.1] - 2021-10-18
+
+Initial release as a standalone project.
+Previously, this project was part of https://github.com/opendatacube/odc-tools.

--- a/README.rst
+++ b/README.rst
@@ -71,6 +71,33 @@ Sample ``environment.yml`` is provided below.
        - odc-stac
 
 
+Developing
+##########
+
+To develop ``odc-stac`` locally using pip (assuming you have virtualenvwrapper_ installed):
+
+.. code-block:: bash
+
+   git clone https://github.com/opendatacube/odc-stac
+   cd odc-stac
+   mkvirtualenv odc-stac
+   pip install -e .
+   pip install -r requirements-dev.txt
+
+Run tests with pytest_:
+
+.. code-block:: bash
+
+   pytest
+
+Linting is provided by mypy_, pylint_, and black_:
+
+.. code-block:: bash
+
+   black --check .
+   pylint -v odc
+   mypy odc
+
 
 .. |Documentation Status| image:: https://readthedocs.org/projects/odc-stac/badge/?version=latest
    :target: https://odc-stac.readthedocs.io/en/latest/?badge=latest
@@ -87,3 +114,13 @@ Sample ``environment.yml`` is provided below.
 .. |Binder| image:: https://mybinder.org/badge_logo.svg
    :target: https://mybinder.org/v2/gh/opendatacube/odc-stac/develop?urlpath=lab/workspaces/demo
    :alt: Run Examples in Binder
+
+.. _virtualenvwrapper: https://virtualenvwrapper.readthedocs.io
+
+.. _pytest: https://docs.pytest.org
+
+.. _mypy: http://mypy-lang.org/
+
+.. _pylint: https://pylint.org/
+
+.. _black: https://github.com/psf/black

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,21 +17,7 @@ from pathlib import Path
 
 sys.path.insert(0, os.path.abspath(".."))
 from odc.stac._version import __version__ as _odc_stac_version
-
-
-def compute_nb_hash(folder):
-    nb_hash = (
-        subprocess.check_output(
-            [
-                "/bin/bash",
-                "-c",
-                f"find {folder} -maxdepth 1 -name '*.py' -type f | sort -f -d | xargs cat | sha256sum | cut -b -16",
-            ]
-        )
-        .decode("ascii")
-        .split()[0]
-    )
-    return nb_hash
+from scripts import notebook_hash
 
 
 def ensure_notebooks(https_url, dst_folder):
@@ -54,7 +40,7 @@ def ensure_notebooks(https_url, dst_folder):
 
 # working directory is docs/
 # download pre-rendered notebooks unless folder is already populated
-nb_hash = compute_nb_hash("../notebooks")
+nb_hash = notebook_hash.compute("../notebooks")
 https_url = (
     f"https://packages.dea.ga.gov.au/odc-stac/nb/odc-stac-notebooks-{nb_hash}.tar.gz"
 )

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -22,12 +22,7 @@ s3://datacube-core-deployment/odc-stac/nb/odc-stac-notebooks-{nb_hash}.tar.gz
 https://packages.dea.ga.gov.au/odc-stac/nb/odc-stac-notebooks-{nb_hash}.tar.gz
 ```
 
-Where `{nb_hash}` is a 16 character hash computed from the content of `notebooks/*.py`
-
-```
-find notebooks/ -maxdepth 1 -name '*.py' -type f | \ 
-  sort -f -d | xargs cat | sha256sum | cut -b -16
-```
+Where `{nb_hash}` is a 16 character hash computed from the content of `notebooks/*.py` (see `scripts/notebook_hash.py`).
 
 By the time changes are merged into `develop` branch there should be
 pre-rendered notebook archive accessible without authentication via https.

--- a/notebooks/build.sh
+++ b/notebooks/build.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env sh
+
+set -e
+
+indir="$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)"
+outdir="$(dirname $indir)/docs/notebooks"
+
+mkdir -p $outdir
+
+
+for infile in $(find $indir -type f -maxdepth 1 -name '*py'); do
+    outfile="${outdir}/$(basename ${infile%%.py}.ipynb)"
+    $indir/render-nb.sh $infile $outfile
+done

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,17 @@
+black
+folium
+geopandas
+ipywidgets
+jupytext
+mapclassify
+matplotlib
+mypy
+nbsphinx
+sphinx
+sphinx_rtd_theme
+sphinx-autodoc-typehints
+odc-algo
+odc-ui
+planetary-computer
+pylint
+pytest

--- a/scripts/notebook_hash.py
+++ b/scripts/notebook_hash.py
@@ -1,0 +1,23 @@
+import os.path
+
+import hashlib
+
+
+def compute(folder: str) -> str:
+    hash = hashlib.sha256()
+    paths = [
+        os.path.join(folder, file_name)
+        for file_name in os.listdir(folder)
+        if os.path.splitext(file_name)[1] == ".py"
+    ]
+    paths = sorted(paths, key=str.casefold)
+    for path in paths:
+        with open(path, "rb") as file:
+            bytes = file.read()
+            hash.update(bytes)
+    return hash.hexdigest()
+
+
+if __name__ == "__main__":
+    folder = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "notebooks"))
+    print(compute(folder))


### PR DESCRIPTION
- Adds `requirements-dev.txt` for developing locally w/o conda. Includes README instructions.
- Adds nicer error messages when the pre-built notebooks do not exist.
- Switch to using Python's hashlib instead of `sha256sum` for notebook hash calculations, as `sha256sum` does not exist on some systems (e.g. macos).
- Adds build script for notebooks for building into `docs/` locally.
- Adds a CHANGELOG.md.