### PR TITLE
De-duplicate code in _eo3converter

### DIFF
--- a/odc/stac/_mdtools.py
+++ b/odc/stac/_mdtools.py
@@ -501,6 +501,10 @@ def parse_item(
 
     _grids: Dict[str, GeoBox] = {}
     bands: Dict[str, RasterSource] = {}
+    geometry: Optional[Geometry] = None
+
+    if item.geometry is not None:
+        geometry = Geometry(item.geometry, EPSG4326)
 
     def _get_grid(grid_name: str, asset: pystac.asset.Asset) -> GeoBox:
         grid = _grids.get(grid_name, None)
@@ -527,4 +531,4 @@ def parse_item(
 
         bands[band] = RasterSource(uri=uri, geobox=geobox, meta=meta)
 
-    return ParsedItem(template, bands)
+    return ParsedItem(template, bands, geometry)

--- a/odc/stac/_model.py
+++ b/odc/stac/_model.py
@@ -1,8 +1,9 @@
 """Metadata and data loading model classes."""
 
 from dataclasses import dataclass
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
+from odc.geo import Geometry
 from odc.geo.geobox import GeoBox
 
 
@@ -79,6 +80,18 @@ class RasterCollectionMetadata:
     also reduces memory pressure somewhat as many bands will share one grid object.
     """
 
+    def band_aliases(self) -> Dict[str, List[str]]:
+        """
+        Compute inverse of alias mapping.
+
+        :return:
+          Mapping from canonical name to a list of defined aliases.
+        """
+        out: Dict[str, List[str]] = {}
+        for alias, cn in self.aliases.items():
+            out.setdefault(cn, []).append(alias)
+        return out
+
 
 @dataclass
 class RasterSource:
@@ -115,6 +128,9 @@ class ParsedItem:
 
     bands: Dict[str, RasterSource]
     """Raster bands."""
+
+    geometry: Optional[Geometry] = None
+    """Footprint of the dataset."""
 
 
 @dataclass

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -9,7 +9,13 @@ from odc.stac.bench import (
     run_bench,
 )
 
-CFG = {"*": {"warnings": "ignore"}}
+CFG = {
+    "*": {
+        "warnings": "ignore",
+        # for every asset in every product default to uint16 with nodata=0
+        "assets": {"*": {"data_type": "uint16", "nodata": 0}},
+    }
+}
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
Implement `stac2ds` using `_mdtools` methods followed by conversion
to the datacube model.

Also extract geometry when parsing stac item

Since code in `_mdtools` defaults to `float32, nodata=nan` changes to
benchmark tests were also needed to configure `uint16` as a default
dtype.