### PR TITLE
Adding output geobox computation

### DIFF
--- a/odc/stac/_eo3converter.py
+++ b/odc/stac/_eo3converter.py
@@ -22,6 +22,7 @@ from toolz import dicttoolz
 from ._mdtools import (
     EPSG4326,
     ConversionConfig,
+    _collection_id,
     extract_collection_metadata,
     mk_1x1_geobox,
     mk_sample_item,
@@ -82,13 +83,6 @@ def _to_product(md: RasterCollectionMetadata) -> DatasetType:
         ],
     }
     return DatasetType(_eo3, doc)
-
-
-def _collection_id(item: pystac.item.Item) -> str:
-    if item.collection_id is None:
-        # workaround for some early ODC data
-        return str(item.properties.get("odc:product", "_"))
-    return str(item.collection_id)
 
 
 @singledispatch
@@ -303,8 +297,7 @@ def stac2ds(
     """
     products: Dict[str, DatasetType] = {} if product_cache is None else product_cache
     for item in items:
-        collection_id = item.collection_id or "_"
-        collection_id = str(collection_id)
+        collection_id = _collection_id(item)
         product = products.get(collection_id)
 
         # Have not seen this collection yet, figure it out

--- a/odc/stac/_model.py
+++ b/odc/stac/_model.py
@@ -1,7 +1,7 @@
 """Metadata and data loading model classes."""
 
 from dataclasses import dataclass
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Sequence, Set, Tuple
 
 from odc.geo import Geometry
 from odc.geo.geobox import GeoBox
@@ -131,6 +131,27 @@ class ParsedItem:
 
     geometry: Optional[Geometry] = None
     """Footprint of the dataset."""
+
+    def geoboxes(self, bands: Optional[Sequence[str]] = None) -> Tuple[GeoBox, ...]:
+        """
+        Unique ``GeoBox``s, highest resolution first.
+
+        :param bands: which bands to consider, default is all
+        """
+        if bands is None:
+            bands = list(self.bands)
+
+        def _resolution(g: GeoBox) -> float:
+            return min(g.resolution.map(abs).xy)
+
+        gbx: Set[GeoBox] = set()
+        for name in bands:
+            b = self.bands.get(name, None)
+            if b is not None:
+                if b.geobox is not None:
+                    gbx.add(b.geobox)
+
+        return tuple(sorted(gbx, key=_resolution))
 
 
 @dataclass

--- a/tests/test_mdtools.py
+++ b/tests/test_mdtools.py
@@ -217,8 +217,19 @@ def test_parse_item(sentinel_stac_ms: pystac.item.Item):
     xx = parse_item(item, md)
 
     assert set(xx.bands) == S2_ALL_BANDS
-
     assert xx.bands["B02"].geobox is not None
+
+    assert xx.geoboxes() == xx.geoboxes(S2_ALL_BANDS)
+    assert xx.geoboxes(["B02", "B03"]) == (xx.bands["B02"].geobox,)
+    assert xx.geoboxes(["B01", "B02", "B03"]) == (
+        xx.bands["B02"].geobox,
+        xx.bands["B01"].geobox,
+    )
+    assert xx.geoboxes() == (
+        xx.bands["B02"].geobox,  # 10m
+        xx.bands["B05"].geobox,  # 20m
+        xx.bands["B01"].geobox,  # 60m
+    )
 
     with pytest.warns(UserWarning, match="Common name `rededge` is repeated, skipping"):
         (yy,) = list(parse_items(iter([item]), STAC_CFG))
@@ -259,3 +270,5 @@ def test_parse_item_no_proj(sentinel_stac_ms: pystac.item.Item):
     xx = parse_item(item, md)
     for band in xx.bands.values():
         assert band.geobox is None
+
+    assert xx.geoboxes() == ()

--- a/tests/test_mdtools.py
+++ b/tests/test_mdtools.py
@@ -18,6 +18,7 @@ from odc.stac._mdtools import (
     has_proj_ext,
     is_raster_data,
     parse_item,
+    parse_items,
 )
 
 
@@ -218,6 +219,10 @@ def test_parse_item(sentinel_stac_ms: pystac.item.Item):
     assert set(xx.bands) == S2_ALL_BANDS
 
     assert xx.bands["B02"].geobox is not None
+
+    with pytest.warns(UserWarning, match="Common name `rededge` is repeated, skipping"):
+        (yy,) = list(parse_items(iter([item]), STAC_CFG))
+        assert xx == yy
 
     # Test missing band case
     item = pystac.Item.from_dict(item0.to_dict())


### PR DESCRIPTION
this has no tests yet, these will come, there are a lot of failure paths to indicate incorrect argument usage and such, so it will take some effort.

Main task here is:
  stac_items + "some config" -> GeoBox

Where "some config" could be as little as nothing, but might include things like
- crs
- resolution
- alignment of the output pixel grid
- bounding box in many different forms

```
    # geobox, like --> GeoBox
    # lon,lat      --> geopolygon[epsg:4326]
    # bbox         --> geopolygon[epsg:4326]
    # x,y,crs      --> geopolygon[crs]
    # [items]      --> crs, geopolygon[crs]
    # [items]      --> crs, resolution
    # geopolygon, crs, resolution[, align] --> GeoBox
```


