### PR TITLE
Low level reader functionality

### DIFF
--- a/odc/stac/_model.py
+++ b/odc/stac/_model.py
@@ -187,7 +187,7 @@ class RasterLoadParams:
     Disable use of overview images.
 
     Set to ``False`` to always read from the main image ignoring overview images
-    even present in the data source.
+    even when present in the data source.
     """
 
     resampling: str = "nearest"

--- a/odc/stac/_reader.py
+++ b/odc/stac/_reader.py
@@ -1,0 +1,198 @@
+"""
+Utilities for reading pixels from raster files.
+
+- nodata utilities
+- read + reproject
+"""
+
+import math
+from typing import List, Optional, Tuple
+
+import numpy as np
+import rasterio
+import rasterio.enums
+import rasterio.warp
+from odc.geo.geobox import GeoBox
+from odc.geo.overlap import ReprojectInfo, compute_reproject_roi
+from odc.geo.roi import NormalizedROI, roi_shape, w_
+from odc.geo.warp import resampling_s2rio
+
+from ._model import RasterLoadParams, RasterSource
+
+
+def _resolve_src_nodata(
+    nodata: Optional[float], cfg: RasterLoadParams
+) -> Optional[float]:
+    if cfg.src_nodata_override is not None:
+        return cfg.src_nodata_override
+    if nodata is not None:
+        return nodata
+    return cfg.src_nodata_fallback
+
+
+def _resolve_dst_dtype(src_dtype: str, cfg: RasterLoadParams) -> np.dtype:
+    if cfg.dtype is None:
+        return np.dtype(src_dtype)
+    return np.dtype(cfg.dtype)
+
+
+def _resolve_dst_nodata(
+    dst_dtype: np.dtype, cfg: RasterLoadParams, src_nodata: Optional[float] = None
+):
+    # 1. Configuration
+    # 2. np.nan for float32 outputs
+    # 3. Fall back to source nodata
+    if cfg.fill_value is not None:
+        return dst_dtype.type(cfg.fill_value)
+
+    if dst_dtype.kind == "f":
+        return np.nan
+
+    if src_nodata is not None:
+        return dst_dtype.type(src_nodata)
+
+    return None
+
+
+def _pick_overview(read_shrink: int, overviews: List[int]) -> Optional[int]:
+    if len(overviews) == 0 or read_shrink < overviews[0]:
+        return None
+
+    _idx = 0
+    for idx, ovr in enumerate(overviews):
+        if ovr > read_shrink:
+            break
+        _idx = idx
+
+    return _idx
+
+
+def _rio_geobox(src: rasterio.DatasetReader) -> GeoBox:
+    return GeoBox(src.shape, src.transform, src.crs)
+
+
+def _same_nodata(a: Optional[float], b: Optional[float]) -> bool:
+    if a is None:
+        return b is None
+    if b is None:
+        return False
+    if math.isnan(a):
+        return math.isnan(b)
+    return a == b
+
+
+def _nodata_mask(pix: np.ndarray, nodata: Optional[float]) -> np.ndarray:
+    if pix.dtype.kind == "f":
+        if nodata is None or math.isnan(nodata):
+            return np.isnan(pix)
+        return np.bitwise_or(np.isnan(pix), pix == nodata)
+    if nodata is None:
+        return np.zeros_like(pix, dtype="bool")
+    return pix == nodata
+
+
+def _do_read(
+    src: rasterio.Band,
+    cfg: RasterLoadParams,
+    dst_geobox: GeoBox,
+    rr: ReprojectInfo,
+    dst: Optional[np.ndarray] = None,
+) -> Tuple[NormalizedROI, np.ndarray]:
+    resampling = resampling_s2rio(cfg.resampling)
+    rdr = src.ds
+
+    if dst is not None:
+        _dst = dst[rr.roi_dst]
+    else:
+        _dst = np.ndarray(
+            roi_shape(rr.roi_dst), dtype=_resolve_dst_dtype(src.dtype, cfg)
+        )
+
+    src_nodata0 = rdr.nodatavals[src.bidx - 1]
+    src_nodata = _resolve_src_nodata(src_nodata0, cfg)
+    dst_nodata = _resolve_dst_nodata(_dst.dtype, cfg, src_nodata)
+
+    if rr.paste_ok and rr.read_shrink == 1:
+        rdr.read(src.bidx, out=_dst, window=w_[rr.roi_src])
+
+        if dst_nodata is not None and not _same_nodata(src_nodata, dst_nodata):
+            # remap nodata from source to output
+            np.copyto(_dst, dst_nodata, where=_nodata_mask(_dst, src_nodata))
+    else:
+        # some form of reproject
+        # TODO: support read with integer shrink then reproject more
+        # TODO: deal with int8 inputs
+
+        rasterio.warp.reproject(
+            src,
+            _dst,
+            src_nodata=src_nodata,
+            dst_crs=str(dst_geobox.crs),
+            dst_transform=dst_geobox[rr.roi_dst].transform,
+            dst_nodata=dst_nodata,
+            resampling=resampling,
+        )
+
+    return (rr.roi_dst, _dst)
+
+
+def rio_read(
+    src: RasterSource,
+    cfg: RasterLoadParams,
+    dst_geobox: GeoBox,
+    dst: Optional[np.ndarray] = None,
+) -> Tuple[NormalizedROI, np.ndarray]:
+    """
+    Internal read method.
+
+    Returns part of the destination image that overlaps with the given source.
+
+    .. code-block: python
+
+       cfg, geobox, sources = ...
+       mosaic = np.full(geobox.shape, cfg.fill_value, dtype=cfg.dtype)
+
+       for src in sources:
+           roi, pix = rio_read(src, cfg, geobox)
+           assert mosaic[roi].shape == pix.shape
+           assert pix.dtype == mosaic.dtype
+
+           # paste over destination pixels that are empty
+           np.copyto(mosaic[roi], pix, where=(mosaic[roi] == nodata))
+           # OR
+           mosaic[roi] = pix  # if sources are true tiles (no overlaps)
+
+    """
+    # if resampling is `nearest` then ignore sub-pixel translation when deciding
+    # whether we can just paste source into destination
+    ttol = 0.9 if cfg.nearest else 0.05
+
+    with rasterio.open(src.uri, "r", sharing=False) as rdr:
+        assert isinstance(rdr, rasterio.DatasetReader)
+        ovr_idx: Optional[int] = None
+
+        if src.band > rdr.count:
+            raise ValueError(f"No band {src.band} in '{src.uri}'")
+
+        rr: ReprojectInfo = compute_reproject_roi(
+            _rio_geobox(rdr), dst_geobox, ttol=ttol
+        )
+
+        if cfg.use_overviews and rr.read_shrink > 1:
+            ovr_idx = _pick_overview(rr.read_shrink, rdr.overviews(src.band))
+
+        if ovr_idx is None:
+            with rasterio.Env(VSI_CACHE=False):
+                return _do_read(
+                    rasterio.band(rdr, src.band), cfg, dst_geobox, rr, dst=dst
+                )
+
+        # read from overview
+        with rasterio.open(
+            src.uri, "r", sharing=False, overview_level=ovr_idx
+        ) as rdr_ovr:
+            rr = compute_reproject_roi(_rio_geobox(rdr_ovr), dst_geobox, ttol=ttol)
+            with rasterio.Env(VSI_CACHE=False):
+                return _do_read(
+                    rasterio.band(rdr_ovr, src.band), cfg, dst_geobox, rr, dst=dst
+                )

--- a/tests/test-env-py38.yml
+++ b/tests/test-env-py38.yml
@@ -16,7 +16,7 @@ dependencies:
   - pandas
   - pystac >=1.1.0
   - toolz
-  - xarray ~= 0.20.1
+  - xarray ~=0.20.1
 
   # For tests
   - pytest
@@ -47,8 +47,8 @@ dependencies:
   - mypy
   - pylint
 
-  - pip=20
+  - pip =20
   - pip:
       # dev
       - shed
-      - git+https://github.com/opendatacube/odc-geo.git@0f5310940a2e57d2b94753e41b7551816defdf44
+      - odc-geo >=0.1.1a2

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -4,9 +4,11 @@ from odc.stac._model import RasterBandMetadata, RasterLoadParams, RasterSource
 def test_band_load_info():
     meta = RasterBandMetadata(data_type="uint16", nodata=13)
     band = RasterSource("https://example.com/some.tif", meta=meta)
-    assert RasterLoadParams(band).dtype == "uint16"
-    assert RasterLoadParams(band).fill_value == 13
+    assert RasterLoadParams.same_as(meta).dtype == "uint16"
+    assert RasterLoadParams.same_as(band).fill_value == 13
 
     band = RasterSource("file:///")
-    assert RasterLoadParams(band, dtype="uint16").dtype == "uint16"
-    assert RasterLoadParams(band).dtype is None
+    assert RasterLoadParams.same_as(band).dtype == "float32"
+    assert RasterLoadParams().dtype == None
+    assert RasterLoadParams().nearest is True
+    assert RasterLoadParams(resampling="average").nearest is False

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -1,0 +1,59 @@
+from math import isnan
+
+import numpy as np
+
+from odc.stac._model import RasterLoadParams
+from odc.stac._reader import (
+    _pick_overview,
+    _resolve_dst_dtype,
+    _resolve_dst_nodata,
+    _resolve_src_nodata,
+    _same_nodata,
+)
+
+
+def test_same_nodata():
+    _nan = float("nan")
+    assert _same_nodata(None, None) is True
+    assert _same_nodata(_nan, _nan) is True
+    assert _same_nodata(1, None) is False
+    assert _same_nodata(_nan, None) is False
+    assert _same_nodata(None, _nan) is False
+    assert _same_nodata(10, _nan) is False
+    assert _same_nodata(_nan, 10) is False
+    assert _same_nodata(109, 109) is True
+    assert _same_nodata(109, 1) is False
+
+
+def test_resolve_nodata():
+    def _cfg(**kw):
+        return RasterLoadParams("uint8", **kw)
+
+    assert _resolve_src_nodata(None, _cfg()) is None
+    assert _resolve_src_nodata(11, _cfg()) == 11
+    assert _resolve_src_nodata(None, _cfg(src_nodata_fallback=0)) == 0
+    assert _resolve_src_nodata(None, _cfg(src_nodata_fallback=11)) == 11
+    assert _resolve_src_nodata(11, _cfg(src_nodata_fallback=0)) == 11
+    assert _resolve_src_nodata(11, _cfg(src_nodata_override=-1)) == -1
+    assert _resolve_src_nodata(11, _cfg(src_nodata_override=0)) == 0
+
+    assert isnan(_resolve_dst_nodata(np.dtype("float32"), _cfg(), 0))
+    assert _resolve_dst_nodata(np.dtype("uint16"), _cfg(), 0) == 0
+    assert _resolve_dst_nodata(np.dtype("uint16"), _cfg(fill_value=3), 5) == 3
+    assert _resolve_dst_nodata(np.dtype("float32"), _cfg(fill_value=3), 7) == 3
+
+
+def test_resolve_dst_dtype():
+    assert _resolve_dst_dtype("uint8", RasterLoadParams()) == "uint8"
+    assert _resolve_dst_dtype("uint8", RasterLoadParams(dtype="float32")) == "float32"
+
+
+def test_pick_overiew():
+    assert _pick_overview(2, []) is None
+    assert _pick_overview(1, [2, 4]) is None
+    assert _pick_overview(2, [2, 4, 8]) == 0
+    assert _pick_overview(3, [2, 4, 8]) == 0
+    assert _pick_overview(4, [2, 4, 8]) == 1
+    assert _pick_overview(7, [2, 4, 8]) == 1
+    assert _pick_overview(8, [2, 4, 8]) == 2
+    assert _pick_overview(20, [2, 4, 8]) == 2


### PR DESCRIPTION
Given an output geobox and various configurations populate part of the output image space with pixels read from the source.

- Uses appropriate overview image if available and not disabled in configuration
- Normalises output `nodata`
- Detects when pasting is possible to avoid reprojection
   - Pasting from overviews is supported
   - When resampling is `nearest` sub-pixel translation is ignored so that pasting can still happen
- Returns back part of the destination image affected by the source image, this is an important optimization for wide area mosaic loads. That way "fusing" of multiple source only needs to happen in the part of the image that was actually modified
- Can supply output array (if say you know that all sources are proper tiles, or there is only one source to begin with), this reduces memory usage and allows for one less copy.

Example mosaic construction implemented in terms of `rio_read` function:

```python
cfg, geobox, sources = ...
mosaic = np.full(geobox.shape, cfg.fill_value, dtype=cfg.dtype)
for src in sources:
      roi, pix = rio_read(src, cfg, geobox)
      assert mosaic[roi].shape == pix.shape
      assert pix.dtype == mosaic.dtype
      # paste over destination pixels that are empty
      np.copyto(mosaic[roi], pix, where=(mosaic[roi] == nodata))
      # OR
      mosaic[roi] = pix  # if sources are true tiles (no overlaps)
```

### Current Limitations and TODOs

- Single band read is assumed (just like in datacube). This is something that will need to change. Reading rgb images should be supported in one go.
- Only tested in a notebook so far (not part of this PR), proper automated testing will come, thinking how to make good fixtures for this.
- sources with "sub-datasets", like netcdf are not yet supported, there is config for it, but not used at the moment
- Shrink first then reproject is planned but not currently implemented
  - When reading data with large scale down factor it is often useful to perform reprojection in two steps
    1. Read source pixel in the original projection and scale down image some "integer factor" with resampling mode like `average` or `mode` (for categorical data)
    2. Reproject further to final projection/resolution with possibly different resampling method
  - This is likely to produce better looking results, which is important, as significant resolution reduction is often done for human consumption. 
  - It is likely to be cheaper in terms of computation and memory use as well, which again is important for human facing results as there is likely person waiting for this to finish.






