### PR TITLE
Implement temporal grouping and populate time axis

### DIFF
--- a/odc/stac/_load.py
+++ b/odc/stac/_load.py
@@ -67,7 +67,7 @@ def load(
     items: Iterable[pystac.item.Item],
     bands: Optional[Union[str, Sequence[str]]] = None,
     *,
-    groupby: Optional[str] = None,
+    groupby: Optional[str] = "time",
     resampling: Optional[Union[str, Dict[str, str]]] = None,
     chunks: Optional[Dict[str, int]] = None,
     # Geo selection
@@ -118,7 +118,7 @@ def load(
 
      :param groupby:
         Controls what items get placed in to the same pixel plane,
-        supported values are "time", "solar_day" and "nothing",
+        supported values are "time", "solar_day" and "id",
         default is "time"
 
      :param resampling:
@@ -288,7 +288,7 @@ def load(
         crs = cast(MaybeCRS, kw.pop("output_crs", None))
 
     if groupby is None:
-        groupby = "time"
+        groupby = "id"
 
     _parsed = list(parse_items(items, cfg=stac_cfg))
 
@@ -348,7 +348,7 @@ def _extract_timestamps(grouped: List[List[ParsedItem]]) -> List[datetime]:
 
 def _group_items(
     items: List[ParsedItem],
-    groupby: str = "time",
+    groupby: str,
     lon: Optional[float] = None,
 ) -> List[List[ParsedItem]]:
     def _time(xx: ParsedItem):
@@ -363,7 +363,7 @@ def _group_items(
             ts = xx.solar_date_at(lon)
         return (ts.date(), ts, xx.id)
 
-    if groupby == "nothing":
+    if groupby == "id":
         items = sorted(items, key=_time)
         return [[item] for item in items]
 

--- a/odc/stac/_mdtools.py
+++ b/odc/stac/_mdtools.py
@@ -565,11 +565,13 @@ def parse_item(
 
     md = item.common_metadata
     return ParsedItem(
+        item.id,
         template,
         bands,
         geometry,
         datetime=item.datetime,
         datetime_range=(md.start_datetime, md.end_datetime),
+        href=item.get_self_href(),
     )
 
 

--- a/odc/stac/_mdtools.py
+++ b/odc/stac/_mdtools.py
@@ -59,7 +59,7 @@ from ._model import (
 T = TypeVar("T")
 ConversionConfig = Dict[str, Any]
 
-BAND_DEFAULTS = RasterBandMetadata("float32", float("nan"), "1")
+BAND_DEFAULTS = RasterBandMetadata("float32", None, "1")
 
 EPSG4326 = CRS("EPSG:4326")
 

--- a/odc/stac/_mdtools.py
+++ b/odc/stac/_mdtools.py
@@ -695,6 +695,7 @@ def output_geobox(
             align=align,
             like=like,
             geopolygon=geopolygon,
+            bbox=bbox,
             geobox=geobox,
         ).items()
         if v is not None
@@ -750,9 +751,9 @@ def output_geobox(
             params - {"geopolygon", "crs", "align", "resolution"}, "geopolygon"
         )
     elif bbox is not None:
+        report_extra_args(params - {"bbox", "crs", "align", "resolution"}, "bbox")
         x0, y0, x1, y1 = bbox
         geopolygon = geom.box(x0, y0, x1, y1, EPSG4326)
-        report_extra_args(params - {"bbox", "crs", "align", "resolution"}, "bbox")
     elif lat is not None and lon is not None:
         # lon=(x0, x1), lat=(y0, y1)
         report_extra_args(

--- a/odc/stac/_model.py
+++ b/odc/stac/_model.py
@@ -232,6 +232,12 @@ class ParsedItem:
             return self.nominal_datetime
         return _convert_to_solar_time(self.nominal_datetime, lon)
 
+    def solar_date_at(self, lon: float) -> dt.datetime:
+        """
+        Nominal datetime adjusted by longitude.
+        """
+        return _convert_to_solar_time(self.nominal_datetime, lon)
+
 
 @dataclass
 class RasterLoadParams:

--- a/odc/stac/_model.py
+++ b/odc/stac/_model.py
@@ -134,6 +134,9 @@ class ParsedItem:
     Only includes raster bands of interest.
     """
 
+    id: str
+    """Item id copied from STAC."""
+
     collection: RasterCollectionMetadata
     """Collection this Item is part of."""
 
@@ -148,6 +151,9 @@ class ParsedItem:
 
     datetime_range: Tuple[Optional[dt.datetime], Optional[dt.datetime]] = None, None
     """Time period covered."""
+
+    href: Optional[str] = None
+    """Self link from stac item."""
 
     def geoboxes(self, bands: Optional[Sequence[str]] = None) -> Tuple[GeoBox, ...]:
         """

--- a/odc/stac/testing/stac.py
+++ b/odc/stac/testing/stac.py
@@ -1,0 +1,174 @@
+"""
+Making STAC items for testing.
+"""
+from datetime import datetime, timezone
+from typing import Optional
+
+import pystac.asset
+import pystac.item
+import xarray as xr
+from odc.geo.geobox import GeoBox
+from pystac.extensions.projection import ProjectionExtension
+from pystac.extensions.raster import RasterBand, RasterExtension
+from toolz import dicttoolz
+
+from .._mdtools import _group_geoboxes
+from .._model import (
+    ParsedItem,
+    RasterBandMetadata,
+    RasterCollectionMetadata,
+    RasterSource,
+)
+
+STAC_DATE_FMT = "%Y-%m-%dT%H:%M:%S.%fZ"
+STAC_DATE_FMT_SHORT = "%Y-%m-%dT%H:%M:%SZ"
+
+
+def _norm_dates(*args):
+    valid = [a for a in args if a is not None]
+    valid = [
+        datetime.fromisoformat(dt).replace(tzinfo=timezone.utc)
+        for dt in xr.DataArray(list(valid))
+        .astype("datetime64[ns]")
+        .dt.strftime("%Y-%m-%dT%H:%M:%S.%f")
+        .values
+    ]
+    valid = iter(valid)
+    return [next(valid) if a else None for a in args]
+
+
+def b_(
+    name,
+    geobox=None,
+    dtype="int16",
+    nodata=None,
+    unit="1",
+    uri=None,
+    bidx=1,
+    prefix="http://example.com/items/",
+):
+    # pylint: disable=too-many-arguments
+    if uri is None:
+        uri = f"{prefix}{name}.tif"
+    meta = RasterBandMetadata(dtype, nodata, unit)
+    return (name, RasterSource(uri, bidx, geobox=geobox, meta=meta))
+
+
+def mk_parsed_item(
+    bands,
+    datetime=None,
+    start_datetime=None,
+    end_datetime=None,
+    collection="some-collection",
+) -> ParsedItem:
+    """
+    Construct parsed stac item for testing.
+    """
+    # pylint: disable=redefined-outer-name
+    if isinstance(bands, (list, tuple)):
+        bands = dict(bands)
+
+    gboxes = dicttoolz.valmap(lambda b: b.geobox, bands)
+    gboxes = dicttoolz.valfilter(lambda x: x is not None, gboxes)
+
+    if len(gboxes) == 0:
+        band2grid = {b: "default" for b in bands}
+        geobox = None
+    else:
+        grids, band2grid = _group_geoboxes(gboxes)
+        geobox = grids["default"]
+
+    if geobox is not None:
+        geometry = geobox.geographic_extent
+    else:
+        geometry = None
+
+    collection = RasterCollectionMetadata(
+        collection,
+        dicttoolz.valmap(lambda b: b.meta, bands),
+        aliases={},
+        has_proj=(geobox is not None),
+        band2grid=band2grid,
+    )
+    datetime, start_datetime, end_datetime = _norm_dates(
+        datetime, start_datetime, end_datetime
+    )
+
+    return ParsedItem(
+        collection,
+        bands,
+        geometry=geometry,
+        datetime=datetime,
+        datetime_range=(start_datetime, end_datetime),
+    )
+
+
+def _add_proj(gbox: GeoBox, xx):
+    proj = ProjectionExtension.ext(xx, add_if_missing=True)
+    proj.shape = list(gbox.shape.yx)
+    proj.transform = gbox.transform[:6]
+    crs = gbox.crs
+    if crs is not None:
+        epsg = crs.epsg
+        if epsg is not None:
+            proj.epsg = epsg
+        else:
+            proj.wkt2 = crs.wkt
+
+
+def to_stac_item(
+    item: ParsedItem, id: str = "item", href: Optional[str] = None
+) -> pystac.item.Item:
+    # pylint: disable=redefined-builtin
+    gg = item.geometry
+
+    props = {}
+    for n, dt in zip(["start_datetime", "end_datetime"], item.datetime_range):
+        if dt is not None:
+            props[n] = dt.strftime(STAC_DATE_FMT)
+
+    xx = pystac.item.Item(
+        id,
+        geometry=gg.json if gg is not None else None,
+        bbox=list(gg.boundingbox.bbox) if gg is not None else None,
+        datetime=item.datetime,
+        properties=props,
+        collection=item.collection.name,
+    )
+
+    RasterExtension.add_to(xx)
+    gboxes = item.geoboxes()
+    if len(gboxes) > 0:
+        gbox = gboxes[0]
+
+        ProjectionExtension.add_to(xx)
+        _add_proj(gbox, xx)
+
+    for asset_name, b in item.bands.items():
+        xx.add_asset(
+            asset_name,
+            pystac.asset.Asset(b.uri, media_type="image/tiff", roles=["data"]),
+        )
+
+    for asset_name, asset in xx.assets.items():
+        bb = item.bands[asset_name]
+        meta = bb.meta
+        assert meta is not None
+
+        RasterExtension(asset).apply(
+            [
+                RasterBand.create(
+                    data_type=meta.data_type,  # type: ignore
+                    nodata=meta.nodata,
+                    unit=meta.unit,
+                )
+            ]
+        )
+
+        if bb.geobox is not None:
+            _add_proj(bb.geobox, asset)
+
+    if href is not None:
+        xx.set_self_href(href)
+
+    return xx

--- a/odc/stac/testing/stac.py
+++ b/odc/stac/testing/stac.py
@@ -2,7 +2,6 @@
 Making STAC items for testing.
 """
 from datetime import datetime, timezone
-from typing import Optional
 
 import pystac.asset
 import pystac.item
@@ -19,6 +18,8 @@ from .._model import (
     RasterCollectionMetadata,
     RasterSource,
 )
+
+# pylint: disable=redefined-builtin,too-many-arguments
 
 STAC_DATE_FMT = "%Y-%m-%dT%H:%M:%S.%fZ"
 STAC_DATE_FMT_SHORT = "%Y-%m-%dT%H:%M:%SZ"
@@ -47,7 +48,6 @@ def b_(
     bidx=1,
     prefix="http://example.com/items/",
 ):
-    # pylint: disable=too-many-arguments
     if uri is None:
         uri = f"{prefix}{name}.tif"
     meta = RasterBandMetadata(dtype, nodata, unit)
@@ -59,7 +59,9 @@ def mk_parsed_item(
     datetime=None,
     start_datetime=None,
     end_datetime=None,
+    id="some-item",
     collection="some-collection",
+    href=None,
 ) -> ParsedItem:
     """
     Construct parsed stac item for testing.
@@ -95,11 +97,13 @@ def mk_parsed_item(
     )
 
     return ParsedItem(
+        id,
         collection,
         bands,
         geometry=geometry,
         datetime=datetime,
         datetime_range=(start_datetime, end_datetime),
+        href=href,
     )
 
 
@@ -116,10 +120,7 @@ def _add_proj(gbox: GeoBox, xx):
             proj.wkt2 = crs.wkt
 
 
-def to_stac_item(
-    item: ParsedItem, id: str = "item", href: Optional[str] = None
-) -> pystac.item.Item:
-    # pylint: disable=redefined-builtin
+def to_stac_item(item: ParsedItem) -> pystac.item.Item:
     gg = item.geometry
 
     props = {}
@@ -128,7 +129,7 @@ def to_stac_item(
             props[n] = dt.strftime(STAC_DATE_FMT)
 
     xx = pystac.item.Item(
-        id,
+        item.id,
         geometry=gg.json if gg is not None else None,
         bbox=list(gg.boundingbox.bbox) if gg is not None else None,
         datetime=item.datetime,
@@ -168,7 +169,7 @@ def to_stac_item(
         if bb.geobox is not None:
             _add_proj(bb.geobox, asset)
 
-    if href is not None:
-        xx.set_self_href(href)
+    if item.href is not None:
+        xx.set_self_href(item.href)
 
     return xx

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -246,7 +246,7 @@ def gpd_natural_earth():
 @pytest.fixture()
 def gpd_iso3(gpd_natural_earth):
     def _get(iso3, crs=None):
-        gg = gpd_natural_earth[gpd_natural_earth.iso_a3 == "AUS"]
+        gg = gpd_natural_earth[gpd_natural_earth.iso_a3 == iso3]
         if crs is not None:
             gg = gg.to_crs(crs)
         return gg

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -23,6 +23,7 @@ def test_stac_load_smoketest(sentinel_stac_ms_with_raster_ext: pystac.item.Item)
     assert isinstance(xx.B02.odc, ODCExtension)
     assert xx.B02.shape[0] == 1
     assert xx.B02.odc.geobox.crs == "EPSG:3857"
+    assert xx.time.dtype == "datetime64[ns]"
 
     # Test dc.load name for bands, and alias support
     with pytest.warns(UserWarning, match="`rededge`"):
@@ -169,6 +170,8 @@ def test_group_items():
     assert _group_items([b1, aa, b2], "solar_day") == [[aa, b1, b2]]
     assert _group_items([b2, aa, b1], "solar_day") == [[aa, b1, b2]]
     assert _group_items([aa, b1, b2, cc], "solar_day") == [[cc], [aa, b1, b2]]
+
+    assert _group_items([aa, b1, b2, cc], "solar_day", 150 + 1) == [[aa, cc, b1, b2]]
 
     with pytest.raises(ValueError):
         _ = _group_items([aa], groupby="no-such-mode")

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -148,7 +148,7 @@ def test_group_items():
 
     # check no-op case first
     assert _group_items([], "time") == []
-    assert _group_items([], "nothing") == []
+    assert _group_items([], "id") == []
     assert _group_items([], "solar_day") == []
 
     aa = _mk("a", 15 * 10, "2020-01-02T23:59Z")
@@ -156,10 +156,10 @@ def test_group_items():
     b2 = _mk("b2", 15 * 10 + 2, "2020-01-03T00:01Z")
     cc = _mk("c", 0, "2020-01-02T23:59Z")
 
-    assert _group_items([aa, b1, b2], "nothing") == [[aa], [b1], [b2]]
-    assert _group_items([aa, b2, b1], "nothing") == [[aa], [b1], [b2]]
-    assert _group_items([b1, aa, b2], "nothing") == [[aa], [b1], [b2]]
-    assert _group_items([cc, aa, b1, b2], "nothing") == [[aa], [cc], [b1], [b2]]
+    assert _group_items([aa, b1, b2], "id") == [[aa], [b1], [b2]]
+    assert _group_items([aa, b2, b1], "id") == [[aa], [b1], [b2]]
+    assert _group_items([b1, aa, b2], "id") == [[aa], [b1], [b2]]
+    assert _group_items([cc, aa, b1, b2], "id") == [[aa], [cc], [b1], [b2]]
 
     assert _group_items([aa, b1, b2], "time") == [[aa], [b1, b2]]
     assert _group_items([b1, aa, b2], "time") == [[aa], [b1, b2]]

--- a/tests/test_mdtools.py
+++ b/tests/test_mdtools.py
@@ -513,17 +513,12 @@ def test_mk_parsed_item():
             "2020-01-01",
             "2020-01-01",
             "2021-12-31T23:59:59.9999999Z",
+            href="file:///date/item/1.json",
         ),
     ],
 )
 def test_round_trip(parsed_item: ParsedItem):
     item = to_stac_item(parsed_item)
-    md = extract_collection_metadata(item)
-
-    assert parsed_item.collection == md
-    assert parsed_item == parse_item(item, md)
-
-    item = to_stac_item(parsed_item, href="file:///data/item/1.json")
     md = extract_collection_metadata(item)
 
     assert parsed_item.collection == md

--- a/tests/test_mdtools.py
+++ b/tests/test_mdtools.py
@@ -424,7 +424,9 @@ def test_output_geobox(gpd_iso3, parsed_item_s2: ParsedItem):
         {"x": (0, 1), "y": (1, 2)},
         # too many args
         {"lat": (0, 1), "lon": (1, 2), "x": (3, 4), "y": (5, 6)},
+        {"lat": (0, 1), "lon": (1, 2), "bbox": (0, 1, 2, 3)},
         {"lat": (0, 1), "lon": (1, 2), "geopolygon": geom.box(0, 0, 1, 1, "epsg:4326")},
+        {"bbox": (0, 0, 1, 1), "geopolygon": geom.box(0, 0, 1, 1, "epsg:4326")},
         # bad args
         {"like": object()},
     ],

--- a/tests/test_mdtools.py
+++ b/tests/test_mdtools.py
@@ -180,7 +180,7 @@ def test_extract_md(sentinel_stac_ms: pystac.item.Item):
 
     for band in md.bands.values():
         assert band.data_type == "float32"
-        assert math.isnan(band.nodata)
+        assert band.nodata is None
         assert band.unit == "1"
 
     # Test multiple CRS unhappy path

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -44,10 +44,12 @@ def test_solar_day():
     xx = _mk(15.1, "2020-01-02T12:13:14Z")
     assert xx.nominal_datetime != xx.solar_date
     assert xx.nominal_datetime + dt.timedelta(seconds=3600) == xx.solar_date
+    assert xx.nominal_datetime + dt.timedelta(seconds=3600) == xx.solar_date_at(20)
 
     xx = _mk(-15.1, "2020-01-02T12:13:14Z")
     assert xx.nominal_datetime != xx.solar_date
     assert xx.nominal_datetime - dt.timedelta(seconds=3600) == xx.solar_date
+    assert xx.nominal_datetime - dt.timedelta(seconds=3600) == xx.solar_date_at(-20)
 
     xx = mk_parsed_item([b_("b1")], datetime="2000-01-02")
     assert xx.geometry is None

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,4 +1,10 @@
+import datetime as dt
+
+import pytest
+from odc.geo.geobox import GeoBox
+
 from odc.stac._model import RasterBandMetadata, RasterLoadParams, RasterSource
+from odc.stac.testing.stac import b_, mk_parsed_item
 
 
 def test_band_load_info():
@@ -12,3 +18,41 @@ def test_band_load_info():
     assert RasterLoadParams().dtype == None
     assert RasterLoadParams().nearest is True
     assert RasterLoadParams(resampling="average").nearest is False
+
+
+@pytest.mark.parametrize("lon", [0, -179, 179, 10, 23.4])
+def test_mid_longitude(lon: float):
+    gbox = GeoBox.from_bbox([lon - 0.1, 0, lon + 0.1, 1], shape=(100, 100))
+    xx = mk_parsed_item([b_("b1", gbox)])
+    assert xx.geometry is not None
+    assert xx.geometry.crs == "epsg:4326"
+    assert xx.mid_longitude == pytest.approx(lon)
+
+    assert mk_parsed_item([]).mid_longitude is None
+
+
+def test_solar_day():
+    def _mk(lon: float, datetime):
+        gbox = GeoBox.from_bbox([lon - 0.1, 0, lon + 0.1, 1], shape=(100, 100))
+        return mk_parsed_item([b_("b1", gbox)], datetime=datetime)
+
+    for lon in [0, 1, 2, 3, 14, -1, -14, -3]:
+        xx = _mk(lon, "2020-01-02T12:13:14Z")
+        assert xx.mid_longitude == pytest.approx(lon)
+        assert xx.nominal_datetime == xx.solar_date
+
+    xx = _mk(15.1, "2020-01-02T12:13:14Z")
+    assert xx.nominal_datetime != xx.solar_date
+    assert xx.nominal_datetime + dt.timedelta(seconds=3600) == xx.solar_date
+
+    xx = _mk(-15.1, "2020-01-02T12:13:14Z")
+    assert xx.nominal_datetime != xx.solar_date
+    assert xx.nominal_datetime - dt.timedelta(seconds=3600) == xx.solar_date
+
+    xx = mk_parsed_item([b_("b1")], datetime="2000-01-02")
+    assert xx.geometry is None
+    assert xx.nominal_datetime == xx.solar_date
+
+    xx = _mk(10, None)
+    with pytest.raises(ValueError):
+        _ = xx.solar_date


### PR DESCRIPTION
- groupby: time, nothing and solar_day
  - when grouping by solar_day: use mid point of the geobox being loaded as a "reference longitude", rather than just using mid-point of each item. That way items that were captured on the same day but on different sides of `lon=180` will end up grouped together, this is also cheaper computationally as you don't need to compute mid point for each item being processed.
  - timestamp returned on the xarray is still in UTC though, which I guess could be confusing, we might add other coordinates to `time` dimension, like `solar_time`.

- Testing tools to go from "minimal" `ParsedItem` representation to `pystac.Item`
- some other fixes that were highlighted by more tests
  - warn about clashing geo parameters `bbox=` was previously ignored