### PR TITLE
Implement per band resampling and dtype config

### DIFF
--- a/odc/stac/_load.py
+++ b/odc/stac/_load.py
@@ -410,7 +410,7 @@ def load(
 
             dst_roi = (idx[0], *yx_roi)
             dst_slice = dv.data[dst_roi]
-            srcs = [item.resolve_bands([band_name])[band_name] for item in _items]
+            srcs = [item[band_name] for item in _items]
             _ = _fill_2d_slice(srcs, dst_gbox, read_cfg, dst_slice)
 
     return _with_debug_info(ds)

--- a/odc/stac/_mdtools.py
+++ b/odc/stac/_mdtools.py
@@ -559,7 +559,7 @@ def parse_item(
         if uri is None:
             raise ValueError(
                 f"Can not determine absolute path for band: {band}"
-            )  # pragma: nocover (https://github.com/stac-utils/pystac/issues/754)
+            )  # pragma: no cover (https://github.com/stac-utils/pystac/issues/754)
 
         bands[band] = RasterSource(uri=uri, geobox=geobox, meta=meta)
 

--- a/odc/stac/_reader.py
+++ b/odc/stac/_reader.py
@@ -37,8 +37,10 @@ def _resolve_dst_dtype(src_dtype: str, cfg: RasterLoadParams) -> np.dtype:
 
 
 def _resolve_dst_nodata(
-    dst_dtype: np.dtype, cfg: RasterLoadParams, src_nodata: Optional[float] = None
-):
+    dst_dtype: np.dtype,
+    cfg: RasterLoadParams,
+    src_nodata: Optional[float] = None,
+) -> Optional[float]:
     # 1. Configuration
     # 2. np.nan for float32 outputs
     # 3. Fall back to source nodata
@@ -117,7 +119,8 @@ def _do_read(
 
     if roi_is_empty(rr.roi_src):
         # no overlap case
-        np.copyto(_dst, dst_nodata)
+        if dst_nodata is not None:
+            np.copyto(_dst, dst_nodata)
         return (rr.roi_dst, _dst)
 
     if rr.paste_ok and rr.read_shrink == 1:


### PR DESCRIPTION
- Can specify resampling and dtype globally and per band
- Flatter data loading task stream in preparation for threadpool implementation and for progress reporting via iterator observer
- Cleaner alias handling in model classes