### PR TITLE
Add back configure_rio and configure_s3_access

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -17,6 +17,8 @@ odc.stac
    :toctree: _api/
 
    load
+   configure_rio
+   configure_s3_access
 
 odc.stac.bench
 **************

--- a/odc/stac/__init__.py
+++ b/odc/stac/__init__.py
@@ -8,6 +8,7 @@ from ._model import (
     RasterLoadParams,
     RasterSource,
 )
+from ._rio import configure_rio, configure_s3_access
 
 stac_load = load
 
@@ -20,5 +21,7 @@ __all__ = (
     "ConversionConfig",
     "load",
     "stac_load",
+    "configure_rio",
+    "configure_s3_access",
     "__version__",
 )

--- a/odc/stac/_aws.py
+++ b/odc/stac/_aws.py
@@ -1,0 +1,202 @@
+# This file is part of the Open Data Cube, see https://opendatacube.org for more information
+#
+# Copyright (c) 2015-2020 ODC Contributors
+# SPDX-License-Identifier: Apache-2.0
+"""
+Helper methods for working with AWS
+"""
+import json
+import os
+import time
+from typing import Any, Dict, Optional, Tuple
+from urllib.request import urlopen
+
+import botocore
+import botocore.session
+from botocore.credentials import Credentials, ReadOnlyCredentials
+from botocore.session import Session
+
+__all__ = (
+    "ec2_metadata",
+    "ec2_current_region",
+    "botocore_default_region",
+    "auto_find_region",
+    "get_creds_with_retry",
+    "mk_boto_session",
+    "get_aws_settings",
+)
+
+
+def _fetch_text(url: str, timeout: float = 0.1) -> Optional[str]:
+    try:
+        with urlopen(url, timeout=timeout) as resp:
+            if 200 <= resp.getcode() < 300:
+                return resp.read().decode("utf8")
+            return None
+    except IOError:
+        return None
+
+
+def ec2_metadata(timeout: float = 0.1) -> Optional[Dict[str, Any]]:
+    """
+    Grab EC2 instance metadata.
+
+    When running inside AWS returns dictionary describing instance identity.
+    Returns None when not inside AWS
+    """
+
+    txt = _fetch_text(
+        "http://169.254.169.254/latest/dynamic/instance-identity/document", timeout
+    )
+
+    if txt is None:
+        return None
+
+    try:
+        return json.loads(txt)
+    except json.JSONDecodeError:
+        return None
+
+
+def ec2_current_region() -> Optional[str]:
+    """Returns name of the region  this EC2 instance is running in."""
+    cfg = ec2_metadata()
+    if cfg is None:
+        return None
+    return cfg.get("region", None)
+
+
+def botocore_default_region(session: Optional[Session] = None) -> Optional[str]:
+    """Returns default region name as configured on the system."""
+    if session is None:
+        session = botocore.session.get_session()
+    return session.get_config_variable("region")
+
+
+def auto_find_region(
+    session: Optional[Session] = None, default: Optional[str] = None
+) -> str:
+    """
+    Try to figure out which region name to use
+
+    1. Region as configured for this/default session
+    2. Region this EC2 instance is running in
+    3. Value supplied in `default`
+    4. raise exception
+    """
+    region_name = botocore_default_region(session)
+
+    if region_name is None:
+        region_name = ec2_current_region()
+
+    if region_name is not None:
+        return region_name
+
+    if default is None:
+        raise ValueError("Region name is not supplied and default can not be found")
+
+    return default
+
+
+def get_creds_with_retry(
+    session: Session, max_tries: int = 10, sleep: float = 0.1
+) -> Optional[Credentials]:
+    """Attempt to obtain credentials upto `max_tries` times with back off
+    :param session: botocore session, see mk_boto_session
+    :param max_tries: number of attempt before failing and returing None
+    :param sleep: number of seconds to sleep after first failure (doubles on every consecutive failure)
+    """
+    for i in range(max_tries):
+        if i > 0:
+            time.sleep(sleep)
+            sleep = min(sleep * 2, 10)
+
+        creds = session.get_credentials()
+        if creds is not None:
+            return creds
+
+    return None
+
+
+def mk_boto_session(
+    profile: Optional[str] = None,
+    creds: Optional[ReadOnlyCredentials] = None,
+    region_name: Optional[str] = None,
+) -> Session:
+    """Get botocore session with correct `region` configured
+
+    :param profile: profile name to lookup
+    :param creds: Override credentials with supplied data
+    :param region_name: default region_name to use if not configured for a given profile
+    """
+    session = botocore.session.Session(profile=profile)
+
+    if creds is not None:
+        session.set_credentials(creds.access_key, creds.secret_key, creds.token)
+
+    _region = session.get_config_variable("region")
+    if _region is None:
+        if region_name is None or region_name == "auto":
+            _region = auto_find_region(session, default="us-west-2")
+        else:
+            _region = region_name
+        session.set_config_variable("region", _region)
+
+    return session
+
+
+def aws_unsigned_check_env() -> bool:
+    def parse_bool(v: str) -> bool:
+        return v.upper() in ("YES", "Y", "TRUE", "T", "1")
+
+    for evar in ("AWS_UNSIGNED", "AWS_NO_SIGN_REQUEST"):
+        v = os.environ.get(evar, None)
+        if v is not None:
+            return parse_bool(v)
+
+    return False
+
+
+def get_aws_settings(
+    profile: Optional[str] = None,
+    region_name: str = "auto",
+    aws_unsigned: Optional[bool] = None,
+    requester_pays: bool = False,
+) -> Tuple[Dict[str, Any], Credentials]:
+    """
+    Compute ``aws=`` parameter for ``set_default_rio_config``.
+
+    see also ``datacube.utils.rio.set_default_rio_config``
+
+    Returns a tuple of: ``(aws: Dictionary, creds: session credentials from botocore)``.
+
+    Note that credentials are baked in to ``aws`` setting dictionary,
+    however since those might be STS credentials they might require refresh
+    hence they are returned from this function separately as well.
+    """
+    session = mk_boto_session(profile=profile, region_name=region_name)
+
+    region_name = session.get_config_variable("region")
+
+    if aws_unsigned is None:
+        aws_unsigned = aws_unsigned_check_env()
+
+    if aws_unsigned:
+        return (dict(region_name=region_name, aws_unsigned=True), None)
+
+    creds = get_creds_with_retry(session)
+    if creds is None:
+        raise ValueError("Couldn't get credentials")
+
+    cc = creds.get_frozen_credentials()
+
+    return (
+        dict(
+            region_name=region_name,
+            aws_access_key_id=cc.access_key,
+            aws_secret_access_key=cc.secret_key,
+            aws_session_token=cc.token,
+            requester_pays=requester_pays,
+        ),
+        creds,
+    )

--- a/odc/stac/_rio.py
+++ b/odc/stac/_rio.py
@@ -6,11 +6,11 @@
 rasterio helpers
 """
 import threading
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union
 
 import rasterio
 import rasterio.env
-from rasterio.session import Session
+from rasterio.session import AWSSession, Session
 
 SECRET_KEYS = (
     "AWS_ACCESS_KEY_ID",
@@ -39,6 +39,44 @@ SESSION_KEYS = (
     "OSS_ENDPOINT",
     "SWIFT_STORAGE_URL",
 )
+GDAL_CLOUD_DEFAULTS = {
+    "GDAL_DISABLE_READDIR_ON_OPEN": "EMPTY_DIR",
+    "GDAL_HTTP_MAX_RETRY": "10",
+    "GDAL_HTTP_RETRY_DELAY": "0.5",
+}
+
+
+class _GlobalRioConfig:
+    def __init__(self) -> None:
+        self._configured = False
+        self._aws: Optional[Dict[str, Any]] = None
+        self._gdal_opts: Dict[str, Any] = {}
+
+    def set(
+        self,
+        *,
+        aws: Optional[Dict[str, Any]],
+        gdal_opts: Dict[str, Any],
+    ):
+        self._aws = {**aws} if aws is not None else None
+        self._gdal_opts = {**gdal_opts}
+        self._configured = True
+
+    @property
+    def configured(self) -> bool:
+        return self._configured
+
+    def env(self) -> rasterio.env.Env:
+        if self._configured is False:
+            return rasterio.env.Env(_local.session())
+
+        session: Optional[Session] = None
+        if self._aws is not None:
+            session = AWSSession(**self._aws)
+        return rasterio.env.Env(_local.session(session), **self._gdal_opts)
+
+
+_CFG = _GlobalRioConfig()
 
 
 class ThreadSession(threading.local):
@@ -46,13 +84,22 @@ class ThreadSession(threading.local):
     Caches Session between rio_env calls.
     """
 
-    # pylint: disable=too-few-public-methods
-
     def __init__(self) -> None:
         super().__init__()
         self._session: Optional[Session] = None
+        self._aws: Optional[Dict[str, Any]] = None
 
-    def session(self, session: Optional[Session] = None) -> Session:
+    @property
+    def configured(self) -> bool:
+        return self._session is not None
+
+    def reset(self):
+        self._session = None
+        self._aws = None
+        if rasterio.env.hasenv():
+            rasterio.env.delenv()
+
+    def session(self, session: Union[Dict[str, Any], Session] = None) -> Session:
         if self._session is None:
             # first call in this thread
             # 1. Start GDAL environment
@@ -63,12 +110,22 @@ class ThreadSession(threading.local):
                 with rasterio.env.Env() as env:
                     self._session = env.session
             else:
+                if isinstance(session, dict):
+                    self._aws = session
+                    session = AWSSession(**session)
                 self._session = session
 
-        if session is not None:
-            return session
+            assert self._session is not None
+            return self._session
 
-        assert self._session is not None
+        if session is not None:
+            if isinstance(session, Session):
+                return session
+            # TODO: cache more than one session?
+            if session == self._aws:
+                return self._session
+            return AWSSession(**session)
+
         return self._session
 
 
@@ -106,3 +163,97 @@ def rio_env(session=None, **kw):
     re-uses GDAL environment and session between calls.
     """
     return rasterio.env.Env(_local.session(session), **kw)
+
+
+def _set_default_rio_config(
+    aws: Optional[Dict[str, Any]] = None,
+    cloud_defaults: bool = False,
+    **kwargs,
+):
+    opts = {**GDAL_CLOUD_DEFAULTS, **kwargs} if cloud_defaults else {**kwargs}
+    _CFG.set(aws=aws, gdal_opts=opts)
+
+
+def configure_rio(
+    *,
+    cloud_defaults: bool = False,
+    verbose: bool = False,
+    aws: Optional[Dict[str, Any]] = None,
+    **params,
+):
+    """
+    Change GDAL/rasterio configuration.
+
+    Change can be applied locally or on a Dask cluster using ``WorkerPlugin`` mechanism.
+
+    :param cloud_defaults: When ``True`` enable common cloud settings in GDAL
+    :param verbose: Dump GDAL environment settings to stdout
+    :param aws: Arguments for :py:class:`rasterio.session.AWSSession`
+    """
+    # backward compatible flags that don't make a difference anymore
+    activate = params.pop("activate", None)
+    client = params.pop("client", None)
+    if client is not None:
+        pass
+    if activate is not None:
+        pass
+
+    _set_default_rio_config(cloud_defaults=cloud_defaults, aws=aws, **params)
+    if verbose:
+        with _CFG.env():
+            _dump_rio_config()
+
+
+def _dump_rio_config():
+    cfg = get_rio_env()
+    nw = max(len(k) for k in cfg)
+    for k, v in cfg.items():
+        print(f"{k:<{nw}} = {v}")
+
+
+def configure_s3_access(
+    profile: Optional[str] = None,
+    region_name: str = "auto",
+    aws_unsigned: Optional[bool] = None,
+    requester_pays: bool = False,
+    cloud_defaults: bool = True,
+    **gdal_opts,
+):
+    """
+    Credentialize for S3 bucket access or configure public access.
+
+    This function obtains credentials for S3 access and passes them on to
+    processing threads, either local or on dask cluster.
+
+
+    .. note::
+
+       if credentials are STS based they will eventually expire, currently
+       this case is not handled very well, reads will just start failing
+       eventually and will never recover.
+
+    :param profile:        AWS profile name to use
+    :param region_name:    Default region_name to use if not configured for a given/default AWS profile
+    :param aws_unsigned:   If ``True`` don't bother with credentials when reading from S3
+    :param requester_pays: Needed when accessing requester pays buckets
+
+    :param cloud_defaults: Assume files are in the cloud native format, i.e. no side-car files, disables
+                           looking for side-car files, makes things faster but won't work for files
+                           that do have side-car files with extra metadata.
+
+    :param gdal_opts:      Any other option to pass to GDAL environment setup
+
+    :returns: credentials object or ``None`` if ``aws_unsigned=True``
+    """
+    # pylint: disable=import-outside-toplevel
+    from ._aws import get_aws_settings
+
+    aws, creds = get_aws_settings(
+        profile=profile,
+        region_name=region_name,
+        aws_unsigned=aws_unsigned,
+        requester_pays=requester_pays,
+    )
+
+    _set_default_rio_config(aws=aws, cloud_defaults=cloud_defaults, **gdal_opts)
+    return creds

--- a/odc/stac/_version.py
+++ b/odc/stac/_version.py
@@ -1,2 +1,2 @@
 """version information only."""
-__version__ = "0.2.4"
+__version__ = "0.3.0a0"

--- a/odc/stac/testing/fixtures.py
+++ b/odc/stac/testing/fixtures.py
@@ -1,6 +1,12 @@
 """
 Test fixture construction utilities.
 """
+import atexit
+import os
+import pathlib
+import shutil
+import tempfile
+from collections.abc import Mapping, Sequence
 from contextlib import contextmanager
 from typing import Generator
 
@@ -19,3 +25,45 @@ def with_temp_tiff(data: xr.DataArray, **cog_opts) -> Generator[str, None, None]
     with rasterio.MemoryFile() as mem:
         data.odc.write_cog(mem.name, **cog_opts)
         yield mem.name
+
+
+def write_files(file_dict):
+    """
+    Convenience method for writing a bunch of files to a temporary directory.
+
+    Dict format is "filename": "text content"
+
+    If content is another dict, it is created recursively in the same manner.
+
+    writeFiles({'test.txt': 'contents of text file'})
+
+    :return: Created temporary directory path
+    """
+    containing_dir = tempfile.mkdtemp(suffix="testrun")
+    _write_files_to_dir(containing_dir, file_dict)
+
+    def remove_if_exists(path):
+        if os.path.exists(path):
+            shutil.rmtree(path)
+
+    atexit.register(remove_if_exists, containing_dir)
+    return pathlib.Path(containing_dir)
+
+
+def _write_files_to_dir(directory_path, file_dict):
+    """
+    Convenience method for writing a bunch of files to a given directory.
+    """
+    for filename, contents in file_dict.items():
+        path = os.path.join(directory_path, filename)
+        if isinstance(contents, Mapping):
+            os.mkdir(path)
+            _write_files_to_dir(path, contents)
+        else:
+            with open(path, "w", encoding="utf8") as f:
+                if isinstance(contents, str):
+                    f.write(contents)
+                elif isinstance(contents, Sequence):
+                    f.writelines(contents)
+                else:
+                    raise ValueError(f"Unexpected file contents: {type(contents)}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 Test for SQS to DC tool
 """
 import json
+import os
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -252,3 +253,11 @@ def gpd_iso3(gpd_natural_earth):
         return gg
 
     yield _get
+
+
+@pytest.fixture()
+def without_aws_env(monkeypatch):
+    for e in os.environ:
+        if e.startswith("AWS_"):
+            monkeypatch.delenv(e, raising=False)
+    yield

--- a/tests/test_utils_aws.py
+++ b/tests/test_utils_aws.py
@@ -1,0 +1,155 @@
+# This file is part of the Open Data Cube, see https://opendatacube.org for more information
+#
+# Copyright (c) 2015-2020 ODC Contributors
+# SPDX-License-Identifier: Apache-2.0
+import json
+from unittest import mock
+
+import pytest
+
+from odc.stac._aws import (
+    _fetch_text,
+    auto_find_region,
+    ec2_current_region,
+    get_aws_settings,
+    get_creds_with_retry,
+    mk_boto_session,
+)
+from odc.stac.testing.fixtures import write_files
+
+
+def _json(**kw):
+    return json.dumps(kw)
+
+
+def mock_urlopen(text, code=200):
+    m = mock.MagicMock()
+    m.getcode.return_value = code
+    m.read.return_value = text.encode("utf8")
+    m.__enter__.return_value = m
+    return m
+
+
+def test_ec2_current_region():
+    tests = [
+        (None, None),
+        (_json(region="TT"), "TT"),
+        (_json(x=3), None),
+        ("not valid json", None),
+    ]
+
+    for (rv, expect) in tests:
+        with mock.patch("odc.stac._aws._fetch_text", return_value=rv):
+            assert ec2_current_region() == expect
+
+
+@mock.patch("odc.stac._aws.botocore_default_region", return_value=None)
+def test_auto_find_region(*mocks):
+    with mock.patch("odc.stac._aws._fetch_text", return_value=None):
+        with pytest.raises(ValueError):
+            auto_find_region()
+
+    with mock.patch("odc.stac._aws._fetch_text", return_value=_json(region="TT")):
+        assert auto_find_region() == "TT"
+
+
+@mock.patch("odc.stac._aws.botocore_default_region", return_value="tt-from-botocore")
+def test_auto_find_region_2(*mocks):
+    assert auto_find_region() == "tt-from-botocore"
+
+
+def test_fetch_text():
+    with mock.patch("odc.stac._aws.urlopen", return_value=mock_urlopen("", 505)):
+        assert _fetch_text("http://localhost:8817") is None
+
+    with mock.patch("odc.stac._aws.urlopen", return_value=mock_urlopen("text", 200)):
+        assert _fetch_text("http://localhost:8817") == "text"
+
+    def fake_urlopen(*args, **kw):
+        raise IOError("Always broken")
+
+    with mock.patch("odc.stac._aws.urlopen", fake_urlopen):
+        assert _fetch_text("http://localhost:8817") is None
+
+
+def test_get_aws_settings(monkeypatch, without_aws_env):
+
+    pp = write_files(
+        {
+            "config": """
+[default]
+region = us-west-2
+
+[profile east]
+region = us-east-1
+[profile no_region]
+""",
+            "credentials": """
+[default]
+aws_access_key_id = AKIAWYXYXYXYXYXYXYXY
+aws_secret_access_key = fake-fake-fake
+[east]
+aws_access_key_id = AKIAEYXYXYXYXYXYXYXY
+aws_secret_access_key = fake-fake-fake
+""",
+        }
+    )
+
+    assert (pp / "credentials").exists()
+    assert (pp / "config").exists()
+
+    monkeypatch.setenv("AWS_CONFIG_FILE", str(pp / "config"))
+    monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", str(pp / "credentials"))
+
+    aws, creds = get_aws_settings()
+    assert aws["region_name"] == "us-west-2"
+    assert aws["aws_access_key_id"] == "AKIAWYXYXYXYXYXYXYXY"
+    assert aws["aws_secret_access_key"] == "fake-fake-fake"
+
+    sess = mk_boto_session(
+        profile="no_region", creds=creds.get_frozen_credentials(), region_name="mordor"
+    )
+
+    assert (
+        sess.get_credentials().get_frozen_credentials()
+        == creds.get_frozen_credentials()
+    )
+
+    aws, creds = get_aws_settings(profile="east")
+    assert aws["region_name"] == "us-east-1"
+    assert aws["aws_access_key_id"] == "AKIAEYXYXYXYXYXYXYXY"
+    assert aws["aws_secret_access_key"] == "fake-fake-fake"
+
+    aws, creds = get_aws_settings(aws_unsigned=True)
+    assert creds is None
+    assert aws["region_name"] == "us-west-2"
+    assert aws["aws_unsigned"] is True
+
+    aws, creds = get_aws_settings(
+        profile="no_region", region_name="us-west-1", aws_unsigned=True
+    )
+
+    assert creds is None
+    assert aws["region_name"] == "us-west-1"
+    assert aws["aws_unsigned"] is True
+
+    with mock.patch("odc.stac._aws._fetch_text", return_value=_json(region="mordor")):
+        aws, creds = get_aws_settings(profile="no_region", aws_unsigned=True)
+
+        assert aws["region_name"] == "mordor"
+        assert aws["aws_unsigned"] is True
+
+
+@mock.patch("odc.stac._aws.get_creds_with_retry", return_value=None)
+def test_get_aws_settings_no_credentials(without_aws_env):
+    # get_aws_settings should fail when credentials are not available
+    with pytest.raises(ValueError, match="Couldn't get credentials"):
+        aws, creds = get_aws_settings(region_name="fake")
+
+
+def test_creds_with_retry():
+    session = mock.MagicMock()
+    session.get_credentials = mock.MagicMock(return_value=None)
+
+    assert get_creds_with_retry(session, 2, 0.01) is None
+    assert session.get_credentials.call_count == 2


### PR DESCRIPTION
- bumped version to 0.3.0a0
- Copied some of the aws setup code from datacube-core lib
- Adding `_GlobalRioConfig` to keep track of explicitly supplied user config (via `configure_{rio,s3_access}`)
  - S3 credentials/settings configured with `configure_s3_access` will be copied to workers
  - If credentials are not configured then each worker needs to have access to their own credentials, having `AWS_` env vars will trigger credentialization on each worker.
  - Currently each worker thread gets their own credentials, this might cause issues when using machine credentials on many-core instances as all threads will issue sts requests.
  - Not sure what happens when machine credentials expire, I think `rasterio via boto` checks for approaching expiry and gets new set of tokens.
- Currently only aws credentials can be passed on to Dask workers, others will need to be configured via environment variables on the workers
 
