### PR TITLE
Fix packaging and bump version to 0.3.0a1

### DIFF
--- a/odc/stac/_version.py
+++ b/odc/stac/_version.py
@@ -1,2 +1,2 @@
 """version information only."""
-__version__ = "0.3.0a0"
+__version__ = "0.3.0a1"

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,10 +19,9 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Intended Audience :: Developers
     Operating System :: OS Independent
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Topic :: Software Development :: Libraries :: Python Modules
     Topic :: Scientific/Engineering :: GIS
 
@@ -30,7 +29,7 @@ classifiers =
 include_package_data = true
 zip_safe = false
 packages = find_namespace:
-python_requires = >=3.6
+python_requires = >=3.8
 tests_require =
     pytest
     deepdiff
@@ -38,6 +37,8 @@ tests_require =
 install_requires =
     affine
     odc-geo>=0.1.3
+    rasterio
+    dask[array]
     jinja2
     numpy
     pandas


### PR DESCRIPTION
- was missing `rasterio` and `dask[array]`
- also we depend on 3.8 Python features, so bumping that up too