### PR TITLE
Progress reporting and multi-threaded load

### DIFF
--- a/odc/stac/_utils.py
+++ b/odc/stac/_utils.py
@@ -1,0 +1,24 @@
+"""
+Generic tools with only standard lib dependencies.
+"""
+from typing import Iterable, Iterator, Sized, TypeVar
+
+T = TypeVar("T")
+
+
+class SizedIterable(Sized, Iterable[T]):
+    """
+    Lazy sequence of known length but no random access.
+
+    Used to passthrough computation to progress callback like tqdm.
+    """
+
+    def __init__(self, xx: Iterable[T], n: int) -> None:
+        self._xx = iter(xx)
+        self._n = n
+
+    def __len__(self) -> int:
+        return self._n
+
+    def __iter__(self) -> Iterator[T]:
+        yield from self._xx

--- a/odc/stac/_utils.py
+++ b/odc/stac/_utils.py
@@ -1,9 +1,11 @@
 """
 Generic tools with only standard lib dependencies.
 """
-from typing import Iterable, Iterator, Sized, TypeVar
+from concurrent.futures import ThreadPoolExecutor
+from typing import Callable, Iterable, Iterator, Sized, TypeVar, Union
 
 T = TypeVar("T")
+S = TypeVar("S")
 
 
 class SizedIterable(Sized, Iterable[T]):
@@ -22,3 +24,23 @@ class SizedIterable(Sized, Iterable[T]):
 
     def __iter__(self) -> Iterator[T]:
         yield from self._xx
+
+
+def pmap(
+    func: Callable[[T], S],
+    inputs: Iterable[T],
+    pool: Union[ThreadPoolExecutor, int, None],
+) -> Iterator[S]:
+    """
+    Wrapper for ThreadPoolExecutor.map
+    """
+    if pool is None:
+        yield from map(func, inputs)
+        return
+
+    if isinstance(pool, int):
+        pool = ThreadPoolExecutor(pool)
+
+    with pool as _runner:
+        for x in _runner.map(func, inputs):
+            yield x

--- a/odc/stac/_version.py
+++ b/odc/stac/_version.py
@@ -1,2 +1,2 @@
 """version information only."""
-__version__ = "0.3.0rc0"
+__version__ = "0.3.0rc1"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,14 @@
+from odc.stac._utils import SizedIterable
+
+
+def test_sized_iterator():
+    assert len(SizedIterable([], 0)) == 0
+    assert len(SizedIterable(iter([1, 2, 3]), 3)) == 3
+
+    xx = SizedIterable(range(5), 5)
+    assert len(xx) == 5
+    assert list(xx) == list(range(5))
+
+    xx = SizedIterable(range(100, 102), 2)
+    a, b = xx
+    assert a, b == (100, 101)


### PR DESCRIPTION
When loading data directly (no Dask) you now have an option of supplying `progress=tqdm` progress bar into load and
`pool=int|concurrent.futures.ThreadPoolExecutor` to enable concurrent data loading across threads.

also bumping version to `0.1.3rc1`