### PR TITLE
Fix issue #70, release 0.3.0rc2

### DIFF
--- a/docs/samples/save-cog-from-stac.py
+++ b/docs/samples/save-cog-from-stac.py
@@ -3,7 +3,7 @@ Save Landsat 8 pass to GeoTIFF (COG).
 
 This program captures one pass of Band 4 (NIR) of Lansat 8 to a single
 cloud optimized GeoTIFF image. Produced image is rotated to maximize
-proportion of valid pixels in the result. Data is saved in ESPG:3857 at
+proportion of valid pixels in the result. Data is saved in EPSG:3857 at
 native resolution (30m). Produced TIFF is about 4.7GiB.
 
 Data is sourced from Microsoft Planetary Computer:

--- a/odc/stac/_mdtools.py
+++ b/odc/stac/_mdtools.py
@@ -296,14 +296,11 @@ def _group_geoboxes(
     for grid, bands in grids.items():
         if crs is None:
             crs = grid.crs
-        elif grid.crs != crs:
-            raise ValueError("Expect all assets to share common CRS")
 
         grid_name = "default" if grid is g_default else gbox_name(grid)
         if grid_name in named_grids:
-            raise NotImplementedError(
-                "TODO: deal with multiple grids with same sampling distance"
-            )
+            band, *_ = bands
+            grid_name = f"{grid_name}-{band}"
 
         named_grids[grid_name] = grid
         for band in bands:

--- a/odc/stac/_version.py
+++ b/odc/stac/_version.py
@@ -1,2 +1,2 @@
 """version information only."""
-__version__ = "0.3.0rc1"
+__version__ = "0.3.0rc2"

--- a/tests/test_eo3converter.py
+++ b/tests/test_eo3converter.py
@@ -5,7 +5,7 @@ import pystac.asset
 import pystac.collection
 import pystac.item
 import pytest
-from common import STAC_CFG, mk_stac_item
+from common import NO_WARN_CFG, STAC_CFG, mk_stac_item
 from datacube.testutils.io import native_geobox
 from datacube.utils.geometry import Geometry
 from pystac.extensions.projection import ProjectionExtension
@@ -143,13 +143,11 @@ def test_item_to_ds(sentinel_stac_ms: pystac.item.Item):
     with pytest.raises(ValueError):
         product.canonical_measurement("green")
 
-    # Test multiple CRS unhappy path
+    # Test multiple CRS path
     item = item0.clone()
     ProjectionExtension.ext(item.assets["B01"]).epsg = 3857
     assert ProjectionExtension.ext(item.assets["B01"]).crs_string == "EPSG:3857"
-    with pytest.raises(ValueError):
-        with pytest.warns(UserWarning, match="`rededge`"):
-            infer_dc_product(item, STAC_CFG)
+    infer_dc_product(item, NO_WARN_CFG)
 
 
 def test_item_to_ds_no_proj(sentinel_stac_ms: pystac.item.Item):


### PR DESCRIPTION
- Remove same CRS limitation when parsing STAC

This limitation came from datacube dataset model. Now that we do not
used datacube library it is no longer relevant.

Also handling clashing grid names, no longer raising NotImplemented
when grids of the same resolution have different shapes or crs.

Closes #70 