### PR TITLE
Make `botocore` an optional dependency

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -172,7 +172,60 @@ jobs:
         run: |
           mypy odc
 
-  test-with-coverage:
+  test-without-botocore:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
+          cache: "pip"
+          cache-dependency-path: |
+            setup.cfg
+            requirements-dev.txt
+
+      - name: Get Conda Environment from Cache
+        uses: actions/cache@v2
+        id: conda_cache
+        with:
+          path: /tmp/test_env
+          key: ${{ runner.os }}-test-env-py38-without-botocore
+
+      - uses: conda-incubator/setup-miniconda@v2
+        if: steps.conda_cache.outputs.cache-hit != 'true'
+        with:
+          channels: conda-forge,defaults
+          channel-priority: true
+          activate-environment: ""
+          mamba-version: "*"
+          use-mamba: true
+
+      - name: Update PATH
+        shell: bash -l {0}
+        run: |
+          echo "/tmp/test_env/bin" >> $GITHUB_PATH
+
+      - name: Install GDAL
+        shell: bash -l {0}
+        run: mamba install -y gdal
+
+      - name: Install odc-stac
+        shell: bash -l {0}
+        run: pip install -e .
+
+      - name: Install development requirements
+        shell: bash -l {0}
+        run: pip install -r requirements-dev.txt
+
+      - name: Run tests
+        shell: bash -l {0}
+        run: pytest tests
+        env:
+          DASK_TEMPORARY_DIRECTORY: /tmp/dask
+
+  test-with-botocore-and-coverage:
     runs-on: ubuntu-latest
 
     needs:
@@ -198,7 +251,7 @@ jobs:
       - name: Install in Edit mode
         shell: bash
         run: |
-          pip install -e . --no-deps
+          pip install -e '.[botocore]' --no-deps
 
       - name: Run Tests
         shell: bash

--- a/README.rst
+++ b/README.rst
@@ -36,6 +36,12 @@ Using pip
 
    pip install odc-stac
 
+To install with ``botocore`` support (for working with AWS):
+
+.. code-block:: bash
+
+   pip install 'odc-stac[botocore]'
+
 
 Using Conda
 ~~~~~~~~~~~

--- a/odc/stac/_rio.py
+++ b/odc/stac/_rio.py
@@ -246,7 +246,13 @@ def configure_s3_access(
     :returns: credentials object or ``None`` if ``aws_unsigned=True``
     """
     # pylint: disable=import-outside-toplevel
-    from ._aws import get_aws_settings
+    try:
+        from ._aws import get_aws_settings
+    except ImportError as e:
+        raise ImportError(
+            "botocore is required to configure s3 access. "
+            "Install botocore directly or via `pip install 'odc-stac[botocore]'"
+        ) from e
 
     aws, creds = get_aws_settings(
         profile=profile,

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,6 +45,9 @@ install_requires =
     pystac>=1.0.0,<2
     toolz
     xarray>=0.19
+  
+[options.extras_require]
+botocore = botocore
 
 [options.packages.find]
 include =

--- a/tests/test_utils_aws.py
+++ b/tests/test_utils_aws.py
@@ -7,6 +7,7 @@ from unittest import mock
 
 import pytest
 
+_ = pytest.importorskip("botocore")
 from odc.stac._aws import (
     _fetch_text,
     auto_find_region,


### PR DESCRIPTION
~Required because `odc.stac.configure_s3_access` is part of the public API, which imports from `_aws` which requires `botocore`.~

Adds `botocore` as an optional dependency. Includes:

- Nicer import error message when `botocore` is not installed
- Skip aws tests when botocore is not installed
- CI with/without botocore
- README instructions on using `extra_requires` with pip