### PR TITLE
Fix CI and support GCP files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -186,31 +186,6 @@ jobs:
             setup.cfg
             requirements-dev.txt
 
-      - name: Get Conda Environment from Cache
-        uses: actions/cache@v2
-        id: conda_cache
-        with:
-          path: /tmp/test_env
-          key: ${{ runner.os }}-test-env-py38-without-botocore
-
-      - uses: conda-incubator/setup-miniconda@v2
-        if: steps.conda_cache.outputs.cache-hit != 'true'
-        with:
-          channels: conda-forge,defaults
-          channel-priority: true
-          activate-environment: ""
-          mamba-version: "*"
-          use-mamba: true
-
-      - name: Update PATH
-        shell: bash -l {0}
-        run: |
-          echo "/tmp/test_env/bin" >> $GITHUB_PATH
-
-      - name: Install GDAL
-        shell: bash -l {0}
-        run: mamba install -y gdal
-
       - name: Install odc-stac
         shell: bash -l {0}
         run: pip install -e .

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ tests_require =
 install_requires =
     affine
     odc-geo>=0.1.3
-    rasterio
+    rasterio>=1.0.0,!=1.3.0
     dask[array]
     numpy
     pandas


### PR DESCRIPTION
Allows working with sentinel 1 data that uses GCPs.

```python
import folium
import odc.stac
import planetary_computer as pc
import pystac.item
from odc.stac import configure_rio
from tqdm.auto import tqdm

item = pystac.item.Item.from_file(
    "https://planetarycomputer.microsoft.com/api/stac/v1/collections/sentinel-1-grd/items/S1A_EW_GRDM_1SDH_20220630T120320_20220630T120420_043892_053D60"
)

configure_rio(cloud_defaults=True)

xx = odc.stac.load(
    [item],
    crs="epsg:32218",
    bands=["hh"],
    resolution=40,
    patch_url=pc.sign,
    dtype="uint16",
    nodata=0,
    resampling="average",
    progress=tqdm,
    pool=4,
)

# Show it on a map
_map = folium.Map()
xx.hh.odc.add_to(_map, name="hh", cmap="magma", robust=True, fmt="webp", quality=99)
_map.fit_bounds(xx.hh.odc.map_bounds())
display(_map)
```

<img width="376" alt="Screen Shot 2022-07-08 at 1 14 22 pm" src="https://user-images.githubusercontent.com/1428024/177910037-9c1994d4-9728-474d-811c-8ac19b5fa872.png">

