### PR TITLE
Reworking metadata extraction from pystac

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+- Multi band support when parsing STAC items
+- Remove ambiguous alias warnings and errors, instead pick "best" band for a
+  given common name based on a simple heuristic (favour single band assets over
+  multi-band, use alphabet order when band count is the same).
+- Accept `<asset name>.<band index: 1..>` syntax for specifying bands
 ## [v0.3.1] - 2022-06-28
 
 - Use asset key as a canonical name, fixes landsat collection parsing

--- a/odc/stac/_dask.py
+++ b/odc/stac/_dask.py
@@ -9,30 +9,30 @@ from dask.base import normalize_token, tokenize
 
 from ._model import T
 
+# newer version of odc.geo implement __dask_token__
+# only register those if working with older odc.geo
+if getattr(odc.geo.crs.CRS, "__dask_tokenize__", None) is None:
 
-# TODO: these classes should just implement __dask_token__ instead
-@normalize_token.register(odc.geo.crs.CRS)
-def normalize_token_crs(crs):
-    return ("odc.geo.crs.CRS", str(crs))
+    @normalize_token.register(odc.geo.crs.CRS)
+    def normalize_token_crs(crs):
+        return ("odc.geo.crs.CRS", str(crs))
 
+    @normalize_token.register(odc.geo.geobox.GeoBox)
+    def normalize_token_geobox(gbox):
+        crs = gbox.crs
+        return ("odc.geo.geobox.GeoBox", str(crs), *gbox.shape.yx, *gbox.affine[:6])
 
-@normalize_token.register(odc.geo.geobox.GeoBox)
-def normalize_token_geobox(gbox):
-    crs = gbox.crs
-    return ("odc.geo.geobox.GeoBox", str(crs), *gbox.shape.yx, *gbox.affine[:6])
-
-
-@normalize_token.register(odc.geo.geobox.GeoboxTiles)
-def normalize_token_gbt(gbt: odc.geo.geobox.GeoboxTiles):
-    gbox = gbt.base
-    crs = gbox.crs
-    return (
-        "odc.geo.geobox.GeoboxTiles",
-        *gbt.shape.yx,
-        str(crs),
-        *gbox.shape.yx,
-        *gbox.affine[:6],
-    )
+    @normalize_token.register(odc.geo.geobox.GeoboxTiles)
+    def normalize_token_gbt(gbt: odc.geo.geobox.GeoboxTiles):
+        gbox = gbt.base
+        crs = gbox.crs
+        return (
+            "odc.geo.geobox.GeoboxTiles",
+            *gbt.shape.yx,
+            str(crs),
+            *gbox.shape.yx,
+            *gbox.affine[:6],
+        )
 
 
 def tokenize_stream(

--- a/odc/stac/_mdtools.py
+++ b/odc/stac/_mdtools.py
@@ -99,10 +99,17 @@ def band_metadata(
     if rext.bands is None or len(rext.bands) == 0:
         return [default]
 
+    def _norm_nodata(nodata) -> Union[float, None]:
+        if nodata is None:
+            return None
+        if isinstance(nodata, (int, float)):
+            return nodata
+        return float(nodata)
+
     return [
         RasterBandMetadata(
             with_default(band.data_type, default.data_type),
-            with_default(band.nodata, default.nodata),
+            with_default(_norm_nodata(band.nodata), default.nodata),
             with_default(band.unit, default.unit),
         )
         for band in rext.bands

--- a/odc/stac/_mdtools.py
+++ b/odc/stac/_mdtools.py
@@ -123,6 +123,20 @@ def has_proj_ext(item: Union[pystac.item.Item, pystac.collection.Collection]) ->
         return False
 
 
+def has_raster_ext(item: Union[pystac.item.Item, pystac.collection.Collection]) -> bool:
+    """
+    Check if STAC Item/Collection have EOExtension.
+
+    :returns: ``True`` if Raster exetension is enabled
+    :returns: ``False`` if no Rasetr extension was found
+    """
+    try:
+        RasterExtension.validate_has_extension(item, add_if_missing=False)
+        return True
+    except pystac.errors.ExtensionNotImplemented:
+        return False
+
+
 def has_proj_data(asset: pystac.asset.Asset) -> bool:
     """
     Check if STAC Asset contains proj extension data.

--- a/odc/stac/_mdtools.py
+++ b/odc/stac/_mdtools.py
@@ -373,18 +373,6 @@ def alias_map_from_eo(item: pystac.item.Item, quiet: bool = False) -> Dict[str, 
     return dict(_aliases(aliases))
 
 
-def normalise_product_name(name: str) -> str:
-    """
-    Create valid product name from an arbitrary string.
-
-    Right now just maps ``-`` and `` `` to ``_``.
-
-    :param name: Usually comes from ``collection_id``.
-    """
-    # TODO: for now just map `-`,` ` to `_`
-    return name.replace("-", "_").replace(" ", "_")
-
-
 def norm_band_metadata(
     v: Union[RasterBandMetadata, Dict[str, Any]],
     fallback: RasterBandMetadata = BAND_DEFAULTS,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,3 +16,4 @@ odc-ui
 planetary-computer
 pylint
 pytest
+pystac==1.4.0

--- a/tests/common/__init__.py
+++ b/tests/common/__init__.py
@@ -18,8 +18,9 @@ STAC_CFG = {
             "SCL": RasterBandMetadata("uint8", 0, "1"),
             "visual": dict(data_type="uint8", nodata=0, unit="1"),
         },
-        "aliases": {  # Work around duplicate rededge common_name
-            "rededge": "B05",
+        "aliases": {
+            # Work around duplicate rededge common_name
+            # by defining custom unique aliases
             "rededge1": "B05",
             "rededge2": "B06",
             "rededge3": "B07",

--- a/tests/test-env-py38.yml
+++ b/tests/test-env-py38.yml
@@ -14,7 +14,7 @@ dependencies:
   - jinja2
   - numpy
   - pandas
-  - pystac >=1.1.0
+  - pystac ==1.4.0
   - toolz
   - xarray ~=0.20.1
   - odc-geo >=0.2.0

--- a/tests/test_eo3converter.py
+++ b/tests/test_eo3converter.py
@@ -21,8 +21,7 @@ def test_infer_product_collection(
     sentinel_stac_ms_with_raster_ext: pystac.item.Item,
 ):
 
-    with pytest.warns(UserWarning):
-        product = infer_dc_product(sentinel_stac_collection)
+    product = infer_dc_product(sentinel_stac_collection)
     assert product.measurements["SCL"].dtype == "uint8"
     # check aliases from eo extension
     assert product.canonical_measurement("red") == "B04"
@@ -35,7 +34,6 @@ def test_infer_product_collection(
     assert b2g["B02"] == "default"
     assert b2g["B01"] == "g60"
     assert set(b2g.values()) == set("default g20 g60".split(" "))
-    assert set(b2g) == set(product.measurements)
 
     # Check that we can use product derived this way on an Item
     item = sentinel_stac_ms_with_raster_ext.clone()
@@ -63,11 +61,7 @@ def test_infer_product_item(sentinel_stac_ms: pystac.item.Item):
 
     assert item.collection_id in STAC_CFG
 
-    with pytest.warns(
-        UserWarning,
-        match="Aliases are not supported for multi-band assets, skipping `visual`",
-    ):
-        product = infer_dc_product(item, STAC_CFG)
+    product = infer_dc_product(item, STAC_CFG)
 
     assert product.measurements["SCL"].dtype == "uint8"
     assert product.measurements["visual"].dtype == "uint8"
@@ -76,7 +70,6 @@ def test_infer_product_item(sentinel_stac_ms: pystac.item.Item):
     assert product.canonical_measurement("green") == "B03"
     assert product.canonical_measurement("blue") == "B02"
     # check aliases from config
-    assert product.canonical_measurement("rededge") == "B05"
     assert product.canonical_measurement("rededge1") == "B05"
     assert product.canonical_measurement("rededge2") == "B06"
     assert product.canonical_measurement("rededge3") == "B07"
@@ -87,20 +80,12 @@ def test_infer_product_item(sentinel_stac_ms: pystac.item.Item):
     item_no_collection = pystac.item.Item.from_dict(_stac)
     assert item_no_collection.collection_id is None
 
-    with pytest.warns(
-        UserWarning,
-        match="Aliases are not supported for multi-band assets, skipping `visual`",
-    ):
-        product = infer_dc_product(item_no_collection)
+    product = infer_dc_product(item_no_collection)
 
 
 def test_infer_product_raster_ext(sentinel_stac_ms_with_raster_ext: pystac.item.Item):
     item = sentinel_stac_ms_with_raster_ext.clone()
-    with pytest.warns(
-        UserWarning,
-        match="Aliases are not supported for multi-band assets, skipping `visual`",
-    ):
-        product = infer_dc_product(item)
+    product = infer_dc_product(item)
 
     assert product.measurements["SCL"].dtype == "uint8"
     assert product.measurements["visual"].dtype == "uint8"
@@ -118,8 +103,7 @@ def test_item_to_ds(sentinel_stac_ms: pystac.item.Item):
 
     assert item.collection_id in STAC_CFG
 
-    with pytest.warns(UserWarning, match="`rededge`"):
-        product = infer_dc_product(item, STAC_CFG)
+    product = infer_dc_product(item, STAC_CFG)
     ds = _item_to_ds(item, product)
 
     assert set(ds.measurements) == set(product.measurements)
@@ -132,16 +116,14 @@ def test_item_to_ds(sentinel_stac_ms: pystac.item.Item):
     # key names .platform would be None
     assert ds.metadata.platform == "Sentinel-2B"
 
-    with pytest.warns(UserWarning, match="`rededge`"):
-        dss = list(stac2ds(iter([item, item, item]), STAC_CFG))
+    dss = list(stac2ds(iter([item, item, item]), STAC_CFG))
     assert len(dss) == 3
     assert len({id(ds.type) for ds in dss}) == 1
 
     # Test missing band case
     item = item0.clone()
     item.assets.pop("B01")
-    with pytest.warns(UserWarning, match="Missing asset"):
-        ds = _item_to_ds(item, product, STAC_CFG)
+    ds = _item_to_ds(item, product, STAC_CFG)
 
     # Test no eo extension case
     item = item0.clone()
@@ -167,8 +149,7 @@ def test_item_to_ds_no_proj(sentinel_stac_ms: pystac.item.Item):
     )
     assert has_proj_ext(item) is False
 
-    with pytest.warns(UserWarning, match="`rededge`"):
-        product = infer_dc_product(item, STAC_CFG)
+    product = infer_dc_product(item, STAC_CFG)
 
     geom = Geometry(item.geometry, "EPSG:4326")
     ds = _item_to_ds(item, product, STAC_CFG)

--- a/tests/test_eo3converter.py
+++ b/tests/test_eo3converter.py
@@ -11,7 +11,7 @@ from datacube.utils.geometry import Geometry
 from pystac.extensions.projection import ProjectionExtension
 from toolz import dicttoolz
 
-from odc.stac._mdtools import RasterCollectionMetadata, has_proj_ext
+from odc.stac._mdtools import RasterCollectionMetadata, has_proj_ext, has_raster_ext
 from odc.stac.eo3 import infer_dc_product, stac2ds
 from odc.stac.eo3._eo3converter import _compute_uuid, _item_to_ds
 
@@ -20,7 +20,7 @@ def test_infer_product_collection(
     sentinel_stac_collection: pystac.collection.Collection,
     sentinel_stac_ms_with_raster_ext: pystac.item.Item,
 ):
-
+    assert has_raster_ext(sentinel_stac_collection) is True
     product = infer_dc_product(sentinel_stac_collection)
     assert product.measurements["SCL"].dtype == "uint8"
     # check aliases from eo extension
@@ -37,6 +37,7 @@ def test_infer_product_collection(
 
     # Check that we can use product derived this way on an Item
     item = sentinel_stac_ms_with_raster_ext.clone()
+
     ds = _item_to_ds(item, product)
     geobox = native_geobox(ds, basis="B02")
     assert geobox.shape == (10980, 10980)
@@ -85,6 +86,7 @@ def test_infer_product_item(sentinel_stac_ms: pystac.item.Item):
 
 def test_infer_product_raster_ext(sentinel_stac_ms_with_raster_ext: pystac.item.Item):
     item = sentinel_stac_ms_with_raster_ext.clone()
+    assert has_raster_ext(item) is True
     product = infer_dc_product(item)
 
     assert product.measurements["SCL"].dtype == "uint8"

--- a/tests/test_mdtools.py
+++ b/tests/test_mdtools.py
@@ -19,6 +19,7 @@ from odc.stac._mdtools import (
     compute_eo3_grids,
     extract_collection_metadata,
     has_proj_ext,
+    has_raster_ext,
     is_raster_data,
     output_geobox,
     parse_item,
@@ -68,8 +69,12 @@ def test_eo3_grids(sentinel_stac_ms: pystac.item.Item):
     # More than 1 CRS should work
     item = item0.clone()
     ProjectionExtension.ext(item.assets["B01"]).epsg = 3857
+    assert ProjectionExtension.ext(item.assets["B01"]).epsg == 3857
+
+    data_bands = {k: item.assets[k] for k in data_bands}
     grids, b2g = compute_eo3_grids(data_bands)
     assert b2g["B01"] != b2g["B02"]
+    assert grids[b2g["B01"]].crs is not None
     assert grids[b2g["B01"]].crs.epsg == 3857
 
 
@@ -115,6 +120,7 @@ def test_has_proj_ext(sentinel_stac_ms_no_ext: pystac.item.Item):
 
 def test_band_metadata(sentinel_stac_ms_with_raster_ext: pystac.item.Item):
     item = sentinel_stac_ms_with_raster_ext.clone()
+    assert has_raster_ext(item) is True
     asset = item.assets["SCL"]
     bm = band_metadata(asset, RasterBandMetadata("uint16", 0, "1"))
     assert bm == [RasterBandMetadata("uint8", 0, "1")]

--- a/tests/test_mdtools.py
+++ b/tests/test_mdtools.py
@@ -1,5 +1,3 @@
-import math
-
 import pystac
 import pystac.asset
 import pystac.collection
@@ -119,13 +117,15 @@ def test_band_metadata(sentinel_stac_ms_with_raster_ext: pystac.item.Item):
     item = sentinel_stac_ms_with_raster_ext.clone()
     asset = item.assets["SCL"]
     bm = band_metadata(asset, RasterBandMetadata("uint16", 0, "1"))
-    assert bm == RasterBandMetadata("uint8", 0, "1")
+    assert bm == [RasterBandMetadata("uint8", 0, "1")]
 
-    # Test multiple bands per asset cause a warning
+    # Test multiple bands per asset produce multiple outputs
     asset.extra_fields["raster:bands"].append({"nodata": -10})
-    with pytest.warns(UserWarning, match="Defaulting to first band of 2"):
-        bm = band_metadata(asset, RasterBandMetadata("uint16", 0, "1"))
-    assert bm == RasterBandMetadata("uint8", 0, "1")
+    bm = band_metadata(asset, RasterBandMetadata("uint16", 0, "1"))
+    assert bm == [
+        RasterBandMetadata("uint8", 0, "1"),
+        RasterBandMetadata(data_type="uint16", nodata=-10, unit="1"),
+    ]
 
 
 def test_is_raster_data_more():
@@ -157,37 +157,30 @@ def test_extract_md(sentinel_stac_ms: pystac.item.Item):
 
     assert item.collection_id in STAC_CFG
 
-    with pytest.warns(
-        UserWarning,
-        match="Aliases are not supported for multi-band assets, skipping `visual`",
-    ):
-        md = extract_collection_metadata(item, STAC_CFG)
+    md = extract_collection_metadata(item, STAC_CFG)
 
     assert md.name == "sentinel-2-l2a"
 
-    assert set(md.bands) == S2_ALL_BANDS
+    assert set(md.all_bands) == S2_ALL_BANDS
 
     # check defaults were set
     for b in ["B01", "B02", "B03"]:
+        b = (b, 1)
         assert md.bands[b].data_type == "uint16"
         assert md.bands[b].nodata == 0
         assert md.bands[b].unit == "1"
 
-    assert md.bands["SCL"].data_type == "uint8"
-    assert md.bands["visual"].data_type == "uint8"
+    assert md.bands[("SCL", 1)].data_type == "uint8"
+    assert md.bands[("visual", 1)].data_type == "uint8"
 
     # check aliases configuration
-    assert md.aliases["rededge"] == "B05"
-    assert md.aliases["rededge1"] == "B05"
-    assert md.aliases["rededge2"] == "B06"
-    assert md.aliases["rededge3"] == "B07"
+    assert md.aliases["rededge"] == [("B05", 1), ("B06", 1), ("B07", 1), ("B8A", 1)]
+    assert md.aliases["rededge1"] == [("B05", 1)]
+    assert md.aliases["rededge2"] == [("B06", 1)]
+    assert md.aliases["rededge3"] == [("B07", 1)]
 
     # check without config
-    with pytest.warns(
-        UserWarning,
-        match="Aliases are not supported for multi-band assets, skipping `visual`",
-    ):
-        md = extract_collection_metadata(item)
+    md = extract_collection_metadata(item)
 
     for band in md.bands.values():
         assert band.data_type == "float32"
@@ -216,59 +209,55 @@ def test_noassets_case(no_bands_stac):
 def test_extract_md_raster_ext(sentinel_stac_ms_with_raster_ext: pystac.item.Item):
     item = sentinel_stac_ms_with_raster_ext
 
-    with pytest.warns(
-        UserWarning,
-        match="Aliases are not supported for multi-band assets, skipping `visual`",
-    ):
-        md = extract_collection_metadata(item, STAC_CFG)
+    md = extract_collection_metadata(item, STAC_CFG)
 
-    assert md.aliases["red"] == "B04"
-    assert md.aliases["green"] == "B03"
-    assert md.aliases["blue"] == "B02"
+    assert md.aliases["red"] == [("B04", 1), ("visual", 1)]
+    assert md.aliases["green"] == [("B03", 1), ("visual", 2)]
+    assert md.aliases["blue"] == [("B02", 1), ("visual", 3)]
 
 
 def test_parse_item(sentinel_stac_ms: pystac.item.Item):
     item0 = sentinel_stac_ms
     item = pystac.Item.from_dict(item0.to_dict())
 
-    with pytest.warns(
-        UserWarning,
-        match="Aliases are not supported for multi-band assets, skipping `visual`",
-    ):
-        md = extract_collection_metadata(item, STAC_CFG)
+    md = extract_collection_metadata(item, STAC_CFG)
 
     xx = parse_item(item, md)
     assert xx.datetime_range == (None, None)
     assert xx.datetime == item.datetime
     assert xx.nominal_datetime == item.datetime
 
-    assert set(xx.bands) == S2_ALL_BANDS
-    assert xx.bands["B02"].geobox is not None
+    assert all(band in md for band in S2_ALL_BANDS)
+    assert all((band, 1) in md for band in S2_ALL_BANDS)
+    assert item not in xx
+
+    assert set(n for n, _ in xx.bands) == S2_ALL_BANDS
+    assert xx["B02"].geobox is not None
+    assert xx["B02"] is xx[("B02", 1)]
+    assert xx["B02"] is xx["B02.1"]
+    assert xx.get("B02", None) is xx["B02.1"]
 
     assert xx.geoboxes() == xx.geoboxes(S2_ALL_BANDS)
-    assert xx.geoboxes(["B02", "B03"]) == (xx.bands["B02"].geobox,)
+    assert xx.geoboxes(["B02", "B03"]) == (xx["B02"].geobox,)
     assert xx.geoboxes(["B01", "B02", "B03"]) == (
-        xx.bands["B02"].geobox,
-        xx.bands["B01"].geobox,
+        xx["B02"].geobox,
+        xx["B01"].geobox,
     )
     assert xx.geoboxes() == (
-        xx.bands["B02"].geobox,  # 10m
-        xx.bands["B05"].geobox,  # 20m
-        xx.bands["B01"].geobox,  # 60m
+        xx["B02"].geobox,  # 10m
+        xx["B05"].geobox,  # 20m
+        xx["B01"].geobox,  # 60m
     )
 
-    with pytest.warns(
-        UserWarning,
-        match="Aliases are not supported for multi-band assets, skipping `visual`",
-    ):
-        (yy,) = list(parse_items(iter([item]), STAC_CFG))
-        assert xx == yy
+    (yy,) = list(parse_items(iter([item]), STAC_CFG))
+    assert xx == yy
 
     # Test missing band case
     item = pystac.Item.from_dict(item0.to_dict())
     item.assets.pop("B01")
-    with pytest.warns(UserWarning, match="Missing asset"):
-        xx = parse_item(item, md)
+    xx = parse_item(item, md)
+    assert "B01" not in xx
+    assert xx.get("B01", None) is None
 
 
 @pytest.mark.xfail
@@ -293,8 +282,7 @@ def test_parse_item_no_proj(sentinel_stac_ms: pystac.item.Item):
     )
     assert has_proj_ext(item) is False
 
-    with pytest.warns(UserWarning, match="`rededge`"):
-        md = extract_collection_metadata(item, STAC_CFG)
+    md = extract_collection_metadata(item, STAC_CFG)
 
     xx = parse_item(item, md)
     for band in xx.bands.values():
@@ -307,11 +295,7 @@ def test_parse_item_no_proj(sentinel_stac_ms: pystac.item.Item):
 
 @pytest.fixture
 def parsed_item_s2(sentinel_stac_ms: pystac.item.Item):
-    with pytest.warns(
-        UserWarning,
-        match="Aliases are not supported for multi-band assets, skipping `visual`",
-    ):
-        (item,) = parse_items([sentinel_stac_ms], STAC_CFG)
+    (item,) = parse_items([sentinel_stac_ms], STAC_CFG)
     yield item
 
 
@@ -320,9 +304,9 @@ def test_auto_load_params(parsed_item_s2: ParsedItem):
     assert len(xx.geoboxes()) == 3
     crs = xx.geoboxes()[0].crs
 
-    _10m = xx.bands["B02"].geobox.resolution
-    _20m = xx.bands["B05"].geobox.resolution
-    _60m = xx.bands["B01"].geobox.resolution
+    _10m = xx["B02"].geobox.resolution
+    _20m = xx["B05"].geobox.resolution
+    _60m = xx["B01"].geobox.resolution
 
     assert _10m.xy == (10, -10)
     assert _20m.xy == (20, -20)
@@ -394,9 +378,9 @@ def test_output_geobox(gpd_iso3, parsed_item_s2: ParsedItem):
     assert output_geobox([], like=xr_zeros(gbox[:10, :20])) == gbox[:10, :20]
 
     # no resolution/crs
-    assert output_geobox([], bbox=[0, 1, 2, 3]) is None
-    assert output_geobox([], bbox=[0, 1, 2, 3], resolution=10) is None
-    assert output_geobox([], bbox=[0, 1, 2, 3], crs="epsg:4326") is None
+    assert output_geobox([], bbox=(0, 1, 2, 3)) is None
+    assert output_geobox([], bbox=(0, 1, 2, 3), resolution=10) is None
+    assert output_geobox([], bbox=(0, 1, 2, 3), crs="epsg:4326") is None
 
     # lon-lat/x-y/bbox
     gbox = GeoBox.from_bbox((0, -10, 100, 25), resolution=1)
@@ -491,8 +475,8 @@ def test_mk_parsed_item():
     assert item.crs() is None
     assert item.collection.has_proj is False
 
-    assert set(item.bands) == set(["b1", "b2"])
-    assert item.bands["b1"].uri.endswith("b1.tif")
+    assert set(item.bands) == set([("b1", 1), ("b2", 1)])
+    assert item["b1"].uri.endswith("b1.tif")
 
     item = mk_parsed_item(
         [b_("b1"), b_("b2")],
@@ -565,10 +549,10 @@ def test_usgs_v1_1_1_aliases(usgs_landsat_stac_v1_1_1: pystac.Item) -> None:
     parsed_item = next(parse_items([usgs_landsat_stac_v1_1_1]))
     collection = parsed_item.collection
     assert collection.aliases == {
-        "B1": "blue",
-        "B2": "green",
-        "B3": "red",
-        "B4": "nir08",
-        "B5": "swir16",
-        "B7": "swir22",
+        "B1": [("blue", 1)],
+        "B2": [("green", 1)],
+        "B3": [("red", 1)],
+        "B4": [("nir08", 1)],
+        "B5": [("swir16", 1)],
+        "B7": [("swir22", 1)],
     }


### PR DESCRIPTION
- Support multi-band
   - No longer assume asset<-> band correspondence
- Support "missing assets"
  - Don't assume that all the items have all the bands
  - Instead build up collection structure incrementally, item by item
  - Handle missing bands at load time as well   
- Don't fail or ignore or warn when band aliases are ambiguous, it's just too common, instead
   - Keep track of all aliases 
   - Pick a band when ambiguous alias is supplied at load time without a warning
   - Prefer alias pointing to an asset that has a single band (`B0X` for red/green/blue over `visual` band for example)
   - Add an option to specify exactly what is needed with an `asset.{1..}` syntax to request specific band of a specific asset (1-based indexing) 
- Some refactors to enable the above
