### PR TITLE
Change geometry handling logic and other fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   given common name based on a simple heuristic (favour single band assets over
   multi-band, use alphabet order when band count is the same).
 - Accept `<asset name>.<band index: 1..>` syntax for specifying bands
+- Support files with GCP-based geo-reference
+- Robust handling of transforms that "break" item geometry, better handle cases
+  when item geometry doesn't project cleanly into the destination projection
+- Fix error in GDAL environment configuration for non-Dask case 
+
 ## [v0.3.1] - 2022-06-28
 
 - Use asset key as a canonical name, fixes landsat collection parsing

--- a/odc/stac/_dask.py
+++ b/odc/stac/_dask.py
@@ -3,36 +3,9 @@ Various Dask helpers.
 """
 from typing import Any, Callable, Hashable, Iterator, MutableMapping, Optional, Tuple
 
-import odc.geo.crs
-import odc.geo.geobox
-from dask.base import normalize_token, tokenize
+from dask.base import tokenize
 
 from ._model import T
-
-# newer version of odc.geo implement __dask_token__
-# only register those if working with older odc.geo
-if getattr(odc.geo.crs.CRS, "__dask_tokenize__", None) is None:
-
-    @normalize_token.register(odc.geo.crs.CRS)
-    def normalize_token_crs(crs):
-        return ("odc.geo.crs.CRS", str(crs))
-
-    @normalize_token.register(odc.geo.geobox.GeoBox)
-    def normalize_token_geobox(gbox):
-        crs = gbox.crs
-        return ("odc.geo.geobox.GeoBox", str(crs), *gbox.shape.yx, *gbox.affine[:6])
-
-    @normalize_token.register(odc.geo.geobox.GeoboxTiles)
-    def normalize_token_gbt(gbt: odc.geo.geobox.GeoboxTiles):
-        gbox = gbt.base
-        crs = gbox.crs
-        return (
-            "odc.geo.geobox.GeoboxTiles",
-            *gbt.shape.yx,
-            str(crs),
-            *gbox.shape.yx,
-            *gbox.affine[:6],
-        )
 
 
 def tokenize_stream(

--- a/odc/stac/_load.py
+++ b/odc/stac/_load.py
@@ -811,11 +811,10 @@ def _group_items(
 
 
 def _tiles(item: ParsedItem, gbt: GeoboxTiles) -> Iterator[Tuple[int, int]]:
-    # TODO: should probably prefer native geometry if set in proj
-    # TODO: extract geometry from geobox if proj data is available
-    if item.geometry is None:
+    geom = item.safe_geometry(gbt.base.crs)
+    if geom is None:
         raise ValueError("Can not process items without defined footprint")
-    yield from gbt.tiles(item.geometry)
+    yield from gbt.tiles(geom)
 
 
 def _tyx_bins(

--- a/odc/stac/_mdtools.py
+++ b/odc/stac/_mdtools.py
@@ -49,6 +49,7 @@ from toolz import dicttoolz
 
 from ._model import (
     BandKey,
+    BandQuery,
     MDParseConfig,
     ParsedItem,
     RasterBandMetadata,
@@ -727,11 +728,15 @@ def _normalize_geometry(xx: Any) -> Geometry:
     return Geometry(_geojson_to_shapely(_geo), _crs)
 
 
-def _compute_bbox(items: Iterable[ParsedItem], crs: CRS) -> geom.BoundingBox:
+def _compute_bbox(
+    items: Iterable[ParsedItem],
+    crs: CRS,
+    bands: BandQuery = None,
+) -> geom.BoundingBox:
     def _bbox(item: ParsedItem) -> geom.BoundingBox:
-        g = item.geometry
+        g = item.safe_geometry(crs, bands=bands)
         assert g is not None
-        return g.to_crs(crs).boundingbox
+        return g.boundingbox
 
     return geom.bbox_union(map(_bbox, items))
 

--- a/odc/stac/_rio.py
+++ b/odc/stac/_rio.py
@@ -34,6 +34,7 @@ SESSION_KEYS = (
     "AWS_REGION",
     "AWS_S3_ENDPOINT",
     "AWS_NO_SIGN_REQUEST",
+    "AWS_REQUEST_PAYER",
     "AZURE_STORAGE_ACCOUNT",
     "AZURE_NO_SIGN_REQUEST",
     "OSS_ENDPOINT",
@@ -162,6 +163,8 @@ def rio_env(session=None, **kw):
 
     re-uses GDAL environment and session between calls.
     """
+    if session is None:
+        session = kw.pop("_aws", None)
     return rasterio.env.Env(_local.session(session), **kw)
 
 

--- a/odc/stac/_version.py
+++ b/odc/stac/_version.py
@@ -1,2 +1,2 @@
 """version information only."""
-__version__ = "0.3.1"
+__version__ = "0.3.2rc0"

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ tests_require =
 
 install_requires =
     affine
-    odc-geo>=0.1.3
+    odc-geo>=0.2.2
     rasterio>=1.0.0,!=1.3.0
     dask[array]
     numpy

--- a/tests/test-env-py38.yml
+++ b/tests/test-env-py38.yml
@@ -17,7 +17,7 @@ dependencies:
   - pystac ==1.4.0
   - toolz
   - xarray ~=0.20.1
-  - odc-geo >=0.2.0
+  - odc-geo >=0.2.2
 
   # For mypy
   - types-python-dateutil

--- a/tests/test-env-py38.yml
+++ b/tests/test-env-py38.yml
@@ -14,7 +14,7 @@ dependencies:
   - jinja2
   - numpy
   - pandas
-  - pystac ==1.4.0
+  - pystac
   - toolz
   - xarray ~=0.20.1
   - odc-geo >=0.2.2


### PR DESCRIPTION
- Use image geometry from proj extension over an "approximate STAC item geometry" if possible when computing part of the output image given item contributes to (Closes #85).
- Apply configured gdal environment in the "local load case"  (Closes #82).
- Ignore incompatibility between software and data version when interpreting raster extension data, new `pystac` library contains updates to raster extension, but all data source still use older version of raster extension.
 