### PR TITLE
Changes for odc-geo 0.3

### DIFF
--- a/odc/stac/_load.py
+++ b/odc/stac/_load.py
@@ -27,8 +27,8 @@ import xarray as xr
 from dask import array as da
 from dask.base import quote, tokenize
 from dask.utils import ndeepmap
-from odc.geo import CRS, XY, MaybeCRS, SomeResolution
-from odc.geo.geobox import GeoBox, GeoboxTiles
+from odc.geo import CRS, MaybeCRS, SomeResolution
+from odc.geo.geobox import GeoBox, GeoboxAnchor, GeoboxTiles
 from odc.geo.types import Unset
 from odc.geo.xr import xr_coords
 from xarray.core.npcompat import DTypeLike
@@ -213,7 +213,7 @@ def load(
     # Geo selection
     crs: MaybeCRS = Unset(),
     resolution: Optional[SomeResolution] = None,
-    align: Optional[Union[float, int, XY[float]]] = None,
+    anchor: Optional[GeoboxAnchor] = None,
     geobox: Optional[GeoBox] = None,
     bbox: Optional[Tuple[float, float, float, float]] = None,
     lon: Optional[Tuple[float, float]] = None,
@@ -351,9 +351,10 @@ def load(
     :param y:
        Define output bounds in output projection coordinate units
 
-    :param align:
-       Control pixel snapping, default is to align pixel grid to ``X``/``Y``
-       axis such that pixel edges lie on the axis.
+    :param anchor:
+       Controls pixel snapping, default is to align pixel grid to ``X``/``Y``
+       axis such that pixel edges align with ``x=0, y=0``. Other common option is to
+       align pixel centers to ``0,0`` rather than edges.
 
     :param geobox:
        Allows to specify exact region/resolution/projection using
@@ -463,7 +464,8 @@ def load(
         bands=bands,
         crs=crs,
         resolution=resolution,
-        align=align,
+        anchor=anchor,
+        align=kw.get("align", None),
         geobox=geobox,
         like=like,
         geopolygon=geopolygon,

--- a/odc/stac/_load.py
+++ b/odc/stac/_load.py
@@ -29,6 +29,7 @@ from dask.base import quote, tokenize
 from dask.utils import ndeepmap
 from odc.geo import CRS, XY, MaybeCRS, SomeResolution
 from odc.geo.geobox import GeoBox, GeoboxTiles
+from odc.geo.types import Unset
 from odc.geo.xr import xr_coords
 from xarray.core.npcompat import DTypeLike
 
@@ -210,7 +211,7 @@ def load(
     chunks: Optional[Dict[str, int]] = None,
     pool: Union[ThreadPoolExecutor, int, None] = None,
     # Geo selection
-    crs: MaybeCRS = None,
+    crs: MaybeCRS = Unset(),
     resolution: Optional[SomeResolution] = None,
     align: Optional[Union[float, int, XY[float]]] = None,
     geobox: Optional[GeoBox] = None,
@@ -448,7 +449,7 @@ def load(
 
     # normalize args
     # dc.load compatible name for crs is `output_crs`
-    if crs is None:
+    if isinstance(crs, Unset) or crs is None:
         crs = cast(MaybeCRS, kw.pop("output_crs", None))
 
     if groupby is None:

--- a/odc/stac/_model.py
+++ b/odc/stac/_model.py
@@ -19,8 +19,8 @@ from typing import (
 )
 
 from odc.geo import CRS, Geometry, MaybeCRS
-from odc.geo.crs import norm_crs
 from odc.geo.geobox import GeoBox
+from odc.geo.types import Unset
 
 T = TypeVar("T")
 
@@ -309,10 +309,12 @@ class ParsedItem(Mapping[Union[BandKey, str], RasterSource]):
 
     def image_geometry(
         self,
-        crs: MaybeCRS = None,
+        crs: MaybeCRS = Unset(),
         bands: BandQuery = None,
     ) -> Optional[Geometry]:
-        crs = norm_crs(crs)
+        if isinstance(crs, Unset):
+            crs = None
+
         for gbox in self.geoboxes(bands):
             if gbox.crs is not None:
                 if crs is None or crs == gbox.crs:
@@ -323,7 +325,7 @@ class ParsedItem(Mapping[Union[BandKey, str], RasterSource]):
 
     def safe_geometry(
         self,
-        crs: MaybeCRS = None,
+        crs: MaybeCRS = Unset(),
         bands: BandQuery = None,
     ) -> Optional[Geometry]:
         """
@@ -340,8 +342,7 @@ class ParsedItem(Mapping[Union[BandKey, str], RasterSource]):
         if self.geometry is None:
             return None
 
-        crs = norm_crs(crs)
-        if crs is None:
+        if crs is None or isinstance(crs, Unset):
             return self.geometry
 
         N = 100  # minimum number of points along perimiter we desire

--- a/odc/stac/_model.py
+++ b/odc/stac/_model.py
@@ -19,6 +19,7 @@ from typing import (
 )
 
 from odc.geo import CRS, Geometry, MaybeCRS
+from odc.geo.crs import norm_crs
 from odc.geo.geobox import GeoBox
 
 T = TypeVar("T")
@@ -311,6 +312,7 @@ class ParsedItem(Mapping[Union[BandKey, str], RasterSource]):
         crs: MaybeCRS = None,
         bands: BandQuery = None,
     ) -> Optional[Geometry]:
+        crs = norm_crs(crs)
         for gbox in self.geoboxes(bands):
             if gbox.crs is not None:
                 if crs is None or crs == gbox.crs:
@@ -338,6 +340,7 @@ class ParsedItem(Mapping[Union[BandKey, str], RasterSource]):
         if self.geometry is None:
             return None
 
+        crs = norm_crs(crs)
         if crs is None:
             return self.geometry
 

--- a/odc/stac/_version.py
+++ b/odc/stac/_version.py
@@ -1,2 +1,2 @@
 """version information only."""
-__version__ = "0.3.2rc0"
+__version__ = "0.3.2rc1"

--- a/odc/stac/bench/_run.py
+++ b/odc/stac/bench/_run.py
@@ -15,6 +15,7 @@ import pystac.item
 import xarray as xr
 from dask.utils import format_bytes
 from odc.geo import CRS
+from odc.geo.geobox import GeoBox
 from odc.geo.xr import ODCExtension
 
 import odc.stac
@@ -236,6 +237,7 @@ def collect_context_info(
     geobox = xx.odc.geobox
     if geobox is None or geobox.crs is None:
         raise ValueError("Can't find GEO info")
+    assert isinstance(geobox, GeoBox)
     crs = f"epsg:{geobox.crs.epsg}"
     transform = geobox.transform
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,3 +17,4 @@ planetary-computer
 pylint
 pytest
 pystac==1.4.0
+odc-geo==0.3.0rc1

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ tests_require =
 
 install_requires =
     affine
-    odc-geo>=0.2.2
+    odc-geo>=0.3.0rc1
     rasterio>=1.0.0,!=1.3.0,!=1.3.1
     dask[array]
     numpy

--- a/tests/test-env-py38.yml
+++ b/tests/test-env-py38.yml
@@ -17,7 +17,7 @@ dependencies:
   - pystac
   - toolz
   - xarray ~=0.20.1
-  - odc-geo ==0.3.0rc0
+  - rasterio ==1.3.2
 
   # For mypy
   - types-python-dateutil
@@ -55,3 +55,4 @@ dependencies:
   - pip:
       # dev
       - shed
+      - odc-geo ==0.3.0rc1

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -15,7 +15,6 @@ from odc.stac._reader import (
     _resolve_src_nodata,
     _same_nodata,
     rio_read,
-    src_geobox,
 )
 from odc.stac.testing.fixtures import with_temp_tiff
 
@@ -65,18 +64,6 @@ def test_pick_overiew():
     assert _pick_overview(7, [2, 4, 8]) == 1
     assert _pick_overview(8, [2, 4, 8]) == 2
     assert _pick_overview(20, [2, 4, 8]) == 2
-
-
-def test_src_geobox():
-    gbox = GeoBox.from_bbox((-180, -90, 180, 90), shape=(160, 320), tight=True)
-    assert src_geobox(RasterSource("some.tif", geobox=gbox)) is gbox
-
-    xx = xr_zeros(gbox, dtype="int16")
-    assert xx.odc.geobox == gbox
-
-    with with_temp_tiff(xx, compress=None) as uri:
-        assert src_geobox(uri) == gbox
-        assert src_geobox(RasterSource(uri)) == gbox
 
 
 def test_rio_read():


### PR DESCRIPTION
- Remove special handling of GCP based imagery, with GCPGeoBox support in `odc-geo` this is not longer needed
- Changes to support `crs="utm"` feature of the new `odc-geo`  lib, `.load` can now be called with `crs="utm"`, and appropriate utm zone will be picked based on stac items present
- Hide `align=` argument from docs and use `anchor=EDGE|CENTER|(x_pix, y_pix)` instead
  - `align=` was inherited from datacube, but it is confusing and not widely used as you need to supply pixel anchoring in CRS units. `anchor=` still allows the same functionality of exactly pinning pixel grid in the world space but uses pixel relative coordinates instead. It also provides 2 symbolic options `EDGE==(0,0)` and `CENTER==(0.5, 0.5)`. Default is `EDGE`.
  - Given CRS and resolution, there are still infinite number of pixel grids one can have, as you can move the grid by fraction of a pixel and end up with a different grid. To "anchor" the grid we project point `(0,0)` from CRS units to the pixel plane, and translate the grid such that this point aligns with the pixel edge or pixel center, arbitrary fraction of a pixel can also be used, but is less common.
 