### PR TITLE
Release v0.3.2

### DIFF
--- a/docs/rtd-requirements.txt
+++ b/docs/rtd-requirements.txt
@@ -52,7 +52,7 @@ nest-asyncio==1.5.1
 netCDF4==1.5.7
 notebook==6.4.4
 numpy==1.21.2
-odc-geo==0.3.0rc1
+odc-geo==0.3.0
 packaging==21.0
 pandas==1.3.2
 pandocfilters==1.5.0

--- a/odc/stac/_version.py
+++ b/odc/stac/_version.py
@@ -1,2 +1,2 @@
 """version information only."""
-__version__ = "0.3.2rc1"
+__version__ = "0.3.2"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,4 +17,4 @@ planetary-computer
 pylint
 pytest
 pystac==1.4.0
-odc-geo==0.3.0rc1
+odc-geo==0.3.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ tests_require =
 
 install_requires =
     affine
-    odc-geo>=0.3.0rc1
+    odc-geo>=0.3.0
     rasterio>=1.0.0,!=1.3.0,!=1.3.1
     dask[array]
     numpy

--- a/tests/test-env-py38.yml
+++ b/tests/test-env-py38.yml
@@ -55,4 +55,4 @@ dependencies:
   - pip:
       # dev
       - shed
-      - odc-geo ==0.3.0rc1
+      - odc-geo ==0.3.0


### PR DESCRIPTION
- use `odc-geo>=0.3.0`
- bump version of odc-stac