### PR TITLE
closes #90; proposal

### DIFF
--- a/odc/stac/_load.py
+++ b/odc/stac/_load.py
@@ -31,7 +31,7 @@ from odc.geo import CRS, MaybeCRS, SomeResolution
 from odc.geo.geobox import GeoBox, GeoboxAnchor, GeoboxTiles
 from odc.geo.types import Unset
 from odc.geo.xr import xr_coords
-from xarray.core.npcompat import DTypeLike
+from numpy.typing import DTypeLike
 
 from ._dask import unpack_chunks
 from ._mdtools import ConversionConfig, output_geobox, parse_items, with_default

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ install_requires =
     odc-geo>=0.3.0
     rasterio>=1.0.0,!=1.3.0,!=1.3.1
     dask[array]
-    numpy
+    numpy>=1.20.0
     pandas
     pystac>=1.0.0,<2
     toolz

--- a/tests/test-env-py38.yml
+++ b/tests/test-env-py38.yml
@@ -16,8 +16,9 @@ dependencies:
   - pandas
   - pystac
   - toolz
-  - xarray ~=0.20.1
-  - rasterio ==1.3.2
+  - dask ==2022.10.0
+  - xarray ==2022.10.0
+  - rasterio ==1.3.3
 
   # For mypy
   - types-python-dateutil
@@ -49,7 +50,7 @@ dependencies:
   - pyupgrade
   - libcst
   - mypy
-  - pylint
+  - pylint ==2.15.4
 
   - pip =20
   - pip:


### PR DESCRIPTION
I hit the same issue reported in #90 , as in:
```
Python 3.10.6 | packaged by conda-forge | (main, Aug 22 2022, 20:35:26) [GCC 10.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import odc.stac
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/guy/projects/src/odc-stac/odc/stac/__init__.py", line 3, in <module>
    from ._load import load
  File "/home/guy/projects/src/odc-stac/odc/stac/_load.py", line 34, in <module>
    from xarray.core.npcompat import DTypeLike
ImportError: cannot import name 'DTypeLike' from 'xarray.core.npcompat' (/home/guy/anaconda3/envs/testpy/lib/python3.10/site-packages/xarray/core/npcompat.py)
```
This is with xarray 2022.10.0 and python 3.10.6, but also tried combinations of xarray<2022.10.0 and python 3.9.* etc.

I humbly suggest this PR as a fix, by importing the required DTypeLike directly from numpy.typing, if this doesn't mess up anything else. If there's another preferred approach, I'm happy to help/contribute, otherwise look forward to a speedy fix to this issue.