### PR TITLE
Add "continue on error" feature to odc.stac.load

### DIFF
--- a/.github/workflows/build-binder.yml
+++ b/.github/workflows/build-binder.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Build Binder Image
-      uses: jupyterhub/repo2docker-action@0.2
+      uses: jupyterhub/repo2docker-action@0.3
       id: dkr
       with:
         IMAGE_NAME: kirillodc/odc-stac-binder
@@ -44,7 +44,7 @@ jobs:
           DKR: ${{ steps.dkr.outputs.IMAGE_SHA_NAME }}
 
     - name: Publish environment.yaml artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: environment
         path: /tmp/environment.yaml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,6 +95,51 @@ jobs:
         run: |
           mamba env export -p /tmp/test_env
 
+  build-binder-env:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/cache@v3
+        id: binder_cache
+        with:
+          path: /tmp/binder_env
+          key: ${{ runner.os }}-binder-env-${{ hashFiles('binder/environment.yml') }}
+
+      - uses: conda-incubator/setup-miniconda@v2
+        if: steps.binder_cache.outputs.cache-hit != 'true'
+        with:
+          channels: conda-forge
+          channel-priority: true
+          activate-environment: ""
+          mamba-version: "*"
+          use-mamba: true
+
+      - name: Dump Conda Environment Info
+        shell: bash -l {0}
+        if: steps.binder_cache.outputs.cache-hit != 'true'
+        run: |
+          conda info
+          conda list
+          mamba -V
+          conda config --show-sources
+          conda config --show
+          printenv | sort
+
+      - name: Build Python Environment for Notebooks
+        shell: bash -l {0}
+        if: steps.binder_cache.outputs.cache-hit != 'true'
+        run: |
+          cd binder
+          mamba env create -f environment.yml -p /tmp/binder_env
+
+      - name: Check Python Env
+        shell: bash -l {0}
+        if: steps.binder_cache.outputs.cache-hit != 'true'
+        run: |
+          mamba env export -p /tmp/binder_env
+
   run-black-check:
     runs-on: ubuntu-latest
     needs:
@@ -303,6 +348,9 @@ jobs:
   build-notebooks:
     runs-on: ubuntu-latest
 
+    needs:
+      - build-binder-env
+
     steps:
       - uses: actions/checkout@v3
 
@@ -312,22 +360,31 @@ jobs:
           path: docs/notebooks
           key: docs-notebooks-${{ hashFiles('notebooks/*.py') }}
 
+      - name: Get Conda Environment from Cache
+        if: steps.nb_cache.outputs.cache-hit != 'true'
+        uses: actions/cache@v3
+        id: conda_cache
+        with:
+          path: /tmp/binder_env
+          key: ${{ runner.os }}-binder-env-${{ hashFiles('binder/environment.yml') }}
+
+      - name: Update PATH
+        if: steps.nb_cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          echo "/tmp/binder_env/bin" >> $GITHUB_PATH
+
       - name: Run Notebooks
         if: steps.nb_cache.outputs.cache-hit != 'true'
         run: |
-          docker pull $DKR
-
           nb_dir=docs/notebooks
           mkdir -p $nb_dir
           for src in $(find notebooks -type f -maxdepth 1 -name '*py'); do
              dst="$nb_dir/$(basename ${src%%.py}.ipynb)"
              echo "$src -> $dst"
-             docker run -i --entrypoint ./binder/render-nb-pipe.sh $DKR <$src >$dst
+             ./binder/render-nb-pipe.sh <$src >$dst
           done
           ls -lh $nb_dir
-
-        env:
-          DKR: kirillodc/odc-stac-binder:latest
 
   check-docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,14 +9,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: wheels_cache
         with:
           path: ./wheels
@@ -55,9 +55,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: conda_cache
         with:
           path: /tmp/test_env
@@ -101,9 +101,9 @@ jobs:
       - build-test-env-base
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Get Conda Environment from Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: conda_cache
         with:
           path: /tmp/test_env
@@ -125,9 +125,9 @@ jobs:
       - build-test-env-base
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Get Conda Environment from Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: conda_cache
         with:
           path: /tmp/test_env
@@ -154,9 +154,9 @@ jobs:
       - build-test-env-base
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Get Conda Environment from Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: conda_cache
         with:
           path: /tmp/test_env
@@ -175,7 +175,7 @@ jobs:
   test-without-botocore:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup Python
         uses: actions/setup-python@v4
@@ -208,10 +208,10 @@ jobs:
       - run-black-check
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Get Conda Environment from Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: conda_cache
         with:
           path: /tmp/test_env
@@ -260,17 +260,17 @@ jobs:
       - build-wheels
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Get Wheels from Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: wheels_cache
         with:
           path: ./wheels
           key: wheels-${{ github.sha }}
 
       - name: Get Conda Environment from Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: conda_cache
         with:
           path: /tmp/test_env
@@ -304,9 +304,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: nb_cache
         with:
           path: docs/notebooks
@@ -338,17 +338,17 @@ jobs:
       - build-notebooks
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Get Rendered Notebooks
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: nb_cache
         with:
           path: docs/notebooks
           key: docs-notebooks-${{ hashFiles('notebooks/*.py') }}
 
       - name: Get Conda Environment from Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: conda_cache
         with:
           path: /tmp/test_env

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -11,15 +11,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/cache@v2
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
         id: wheels_cache
         with:
           path: ./wheels
           key: wheels-${{ github.sha }}
 
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
 

--- a/.github/workflows/publish-s3.yml
+++ b/.github/workflows/publish-s3.yml
@@ -16,8 +16,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/cache@v2
+    - uses: actions/checkout@v3
+    - uses: actions/cache@v3
       id: wheels_cache
       with:
         path: ./wheels

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Config
       id: cfg
@@ -25,11 +25,11 @@ jobs:
         nb_dir="docs/notebooks"
         nb_hash=$(python scripts/notebook_hash.py)
         echo "Notebooks hash: ${nb_hash}"
-        echo "::set-output name=nb-dir::${nb_dir}"
-        echo "::set-output name=nb-hash::${nb_hash}"
-        echo "::set-output name=nb-archive::odc-stac-notebooks-${nb_hash}.tar.gz"
+        echo "nb-dir=${nb_dir}" >> $GITHUB_OUTPUT
+        echo "nb-hash=${nb_hash}" >> $GITHUB_OUTPUT
+        echo "nb-archive=odc-stac-notebooks-${nb_hash}.tar.gz" >> $GITHUB_OUTPUT
 
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3
       id: nb_cache
       with:
         path: ${{ steps.cfg.outputs.nb-dir }}
@@ -82,7 +82,7 @@ jobs:
         S3_DST: 's3://datacube-core-deployment/odc-stac/nb'
 
     - name: Upload results (artifact)
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: rendered-notebooks
         path: docs/notebooks

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -4,86 +4,140 @@ on:
   workflow_dispatch:
   push:
     paths:
-    - 'notebooks/*py'
-    - '.github/workflows/render.yml'
-
-env:
-  DKR: kirillodc/odc-stac-binder:latest
+      - "notebooks/*py"
+      - ".github/workflows/render.yml"
 
 jobs:
-  render:
+  build-binder-env:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-    - name: Config
-      id: cfg
-      run: |
-        find notebooks/ -maxdepth 1 -name '*.py' -type f | sort -f -d
+      - uses: actions/cache@v3
+        id: binder_cache
+        with:
+          path: /tmp/binder_env
+          key: ${{ runner.os }}-binder-env-${{ hashFiles('binder/environment.yml') }}
 
-        nb_dir="docs/notebooks"
-        nb_hash=$(python scripts/notebook_hash.py)
-        echo "Notebooks hash: ${nb_hash}"
-        echo "nb-dir=${nb_dir}" >> $GITHUB_OUTPUT
-        echo "nb-hash=${nb_hash}" >> $GITHUB_OUTPUT
-        echo "nb-archive=odc-stac-notebooks-${nb_hash}.tar.gz" >> $GITHUB_OUTPUT
+      - uses: conda-incubator/setup-miniconda@v2
+        if: steps.binder_cache.outputs.cache-hit != 'true'
+        with:
+          channels: conda-forge
+          channel-priority: true
+          activate-environment: ""
+          mamba-version: "*"
+          use-mamba: true
 
-    - uses: actions/cache@v3
-      id: nb_cache
-      with:
-        path: ${{ steps.cfg.outputs.nb-dir }}
-        key: docs-notebooks-${{ hashFiles('notebooks/*.py') }}
+      - name: Dump Conda Environment Info
+        shell: bash -l {0}
+        if: steps.binder_cache.outputs.cache-hit != 'true'
+        run: |
+          conda info
+          conda list
+          mamba -V
+          conda config --show-sources
+          conda config --show
+          printenv | sort
 
-    - name: Pull Docker
-      if: steps.nb_cache.outputs.cache-hit != 'true'
-      run: |
-        docker pull $DKR
+      - name: Build Python Environment for Notebooks
+        shell: bash -l {0}
+        if: steps.binder_cache.outputs.cache-hit != 'true'
+        run: |
+          cd binder
+          mamba env create -f environment.yml -p /tmp/binder_env
 
-    - name: Run Notebooks
-      if: steps.nb_cache.outputs.cache-hit != 'true'
-      run: |
-        nb_dir="${{ steps.cfg.outputs.nb-dir }}"
+      - name: Check Python Env
+        shell: bash -l {0}
+        if: steps.binder_cache.outputs.cache-hit != 'true'
+        run: |
+          mamba env export -p /tmp/binder_env
 
-        mkdir -p $nb_dir
-        for src in $(find notebooks -type f -maxdepth 1 -name '*py'); do
-           dst="${nb_dir}/$(basename ${src%%.py}.ipynb)"
-           echo "$src -> $dst"
-           docker run -i --entrypoint ./binder/render-nb-pipe.sh $DKR <$src >$dst
-        done
-        ls -lh ${nb_dir}/
+  render:
+    runs-on: ubuntu-latest
 
-    - name: Package Notebooks
-      run: |
-        nb_dir="${{ steps.cfg.outputs.nb-dir }}"
-        nb_hash="${{ steps.cfg.outputs.nb-hash }}"
-        nb_archive="${{ steps.cfg.outputs.nb-archive }}"
-        echo "DIR: ${nb_dir}"
-        echo "NB hash: $nb_hash"
-        echo "Archive: $nb_archive"
+    needs:
+      - build-binder-env
 
-        (cd $nb_dir && tar cvz .) > "${nb_archive}"
-        ls -lh "${nb_archive}"
-        tar tzf "${nb_archive}"
+    steps:
+      - uses: actions/checkout@v3
 
-    - name: Upload to S3
-      run: |
-        nb_archive="${{ steps.cfg.outputs.nb-archive }}"
-        echo "Using Keys: ...${AWS_ACCESS_KEY_ID:(-4)}/...${AWS_SECRET_ACCESS_KEY:(-4)}"
-        echo "Testing permissions"
-        aws s3 ls "${S3_DST}/" || true
-        aws s3 cp "${nb_archive}" "${S3_DST}/${nb_archive}"
+      - name: Config
+        id: cfg
+        run: |
+          find notebooks/ -maxdepth 1 -name '*.py' -type f | sort -f -d
 
-      env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY }}
-        AWS_DEFAULT_REGION: 'ap-southeast-2'
-        AWS_REGION: 'ap-southeast-2'
-        S3_DST: 's3://datacube-core-deployment/odc-stac/nb'
+          nb_dir="docs/notebooks"
+          nb_hash=$(python scripts/notebook_hash.py)
+          echo "Notebooks hash: ${nb_hash}"
+          echo "nb-dir=${nb_dir}" >> $GITHUB_OUTPUT
+          echo "nb-hash=${nb_hash}" >> $GITHUB_OUTPUT
+          echo "nb-archive=odc-stac-notebooks-${nb_hash}.tar.gz" >> $GITHUB_OUTPUT
 
-    - name: Upload results (artifact)
-      uses: actions/upload-artifact@v3
-      with:
-        name: rendered-notebooks
-        path: docs/notebooks
-        if-no-files-found: error
+      - uses: actions/cache@v3
+        id: nb_cache
+        with:
+          path: ${{ steps.cfg.outputs.nb-dir }}
+          key: docs-notebooks-${{ hashFiles('notebooks/*.py') }}
+
+      - name: Get Conda Environment from Cache
+        if: steps.nb_cache.outputs.cache-hit != 'true'
+        uses: actions/cache@v3
+        id: conda_cache
+        with:
+          path: /tmp/binder_env
+          key: ${{ runner.os }}-binder-env-${{ hashFiles('binder/environment.yml') }}
+
+      - name: Update PATH
+        if: steps.nb_cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          echo "/tmp/binder_env/bin" >> $GITHUB_PATH
+
+      - name: Run Notebooks
+        if: steps.nb_cache.outputs.cache-hit != 'true'
+        run: |
+          nb_dir="${{ steps.cfg.outputs.nb-dir }}"
+
+          mkdir -p $nb_dir
+          for src in $(find notebooks -type f -maxdepth 1 -name '*py'); do
+             dst="${nb_dir}/$(basename ${src%%.py}.ipynb)"
+             echo "$src -> $dst"
+             ./binder/render-nb-pipe.sh <$src >$dst
+          done
+          ls -lh ${nb_dir}/
+
+      - name: Package Notebooks
+        run: |
+          nb_dir="${{ steps.cfg.outputs.nb-dir }}"
+          nb_hash="${{ steps.cfg.outputs.nb-hash }}"
+          nb_archive="${{ steps.cfg.outputs.nb-archive }}"
+          echo "DIR: ${nb_dir}"
+          echo "NB hash: $nb_hash"
+          echo "Archive: $nb_archive"
+
+          (cd $nb_dir && tar cvz .) > "${nb_archive}"
+          ls -lh "${nb_archive}"
+          tar tzf "${nb_archive}"
+
+      - name: Upload to S3
+        run: |
+          nb_archive="${{ steps.cfg.outputs.nb-archive }}"
+          echo "Using Keys: ...${AWS_ACCESS_KEY_ID:(-4)}/...${AWS_SECRET_ACCESS_KEY:(-4)}"
+          echo "Testing permissions"
+          aws s3 ls "${S3_DST}/" || true
+          aws s3 cp "${nb_archive}" "${S3_DST}/${nb_archive}"
+
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY }}
+          AWS_DEFAULT_REGION: "ap-southeast-2"
+          AWS_REGION: "ap-southeast-2"
+          S3_DST: "s3://datacube-core-deployment/odc-stac/nb"
+
+      - name: Upload results (artifact)
+        uses: actions/upload-artifact@v3
+        with:
+          name: rendered-notebooks
+          path: docs/notebooks
+          if-no-files-found: error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [v0.3.4] - TBD
+## [v0.3.4] - 2022-12-08
 
 - Implement `fail_on_error=False` option for skipping over errors while loading data
+- Maintenance of github actions
 
 ## [v0.3.3] - 2022-10-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.3.4] - TBD
+
+- Implement `fail_on_error=False` option for skipping over errors while loading data
+
 ## [v0.3.3] - 2022-10-20
 
 - Fixes to support `xarray >= 2022.10.0`

--- a/odc/stac/_load.py
+++ b/odc/stac/_load.py
@@ -224,6 +224,7 @@ def load(
     geopolygon: Optional[Any] = None,
     # UI
     progress: Optional[Any] = None,
+    fail_on_error: bool = True,
     # stac related
     stac_cfg: Optional[ConversionConfig] = None,
     patch_url: Optional[Callable[[str], str]] = None,
@@ -291,6 +292,9 @@ def load(
 
     :param progress:
        Pass in ``tqdm`` progress bar or similar, only used in non-Dask load.
+
+    :param fail_on_error:
+        Set this to ``False`` to skip over load failures.
 
     :param pool:
        Use thread pool to perform load locally, only used in non-Dask load.
@@ -505,6 +509,7 @@ def load(
         dtype=dtype,
         use_overviews=kw.get("use_overviews", True),
         nodata=kw.get("nodata", None),
+        fail_on_error=fail_on_error,
     )
 
     if patch_url is not None:
@@ -608,6 +613,7 @@ def _resolve_load_cfg(
     dtype: Union[DTypeLike, Dict[str, DTypeLike], None] = None,
     use_overviews: bool = True,
     nodata: Optional[float] = None,
+    fail_on_error: bool = True,
 ) -> Dict[str, RasterLoadParams]:
     def _dtype(name: str, band_dtype: Optional[str], fallback: str) -> str:
         if dtype is None:
@@ -639,6 +645,7 @@ def _resolve_load_cfg(
             fill_value=_fill_value(band),
             use_overviews=use_overviews,
             resampling=_resampling(name, "nearest"),
+            fail_on_error=fail_on_error,
         )
 
     return {name: _resolve(name, band) for name, band in bands.items()}

--- a/odc/stac/_load.py
+++ b/odc/stac/_load.py
@@ -27,11 +27,11 @@ import xarray as xr
 from dask import array as da
 from dask.base import quote, tokenize
 from dask.utils import ndeepmap
+from numpy.typing import DTypeLike
 from odc.geo import CRS, MaybeCRS, SomeResolution
 from odc.geo.geobox import GeoBox, GeoboxAnchor, GeoboxTiles
 from odc.geo.types import Unset
 from odc.geo.xr import xr_coords
-from numpy.typing import DTypeLike
 
 from ._dask import unpack_chunks
 from ._mdtools import ConversionConfig, output_geobox, parse_items, with_default
@@ -330,13 +330,17 @@ def load(
     regardless of the requested bounding box.
 
     :param crs:
-       Load data in a given CRS
+       Load data in a given CRS. Special name of ``"utm"`` is also understood, in which case an
+       appropriate UTM projection will be picked based on the output bounding box.
 
     :param resolution:
-       Set resolution of output in ``Y, X`` order, it is common for ``Y`` to be negative,
-       e.g. ``resolution=(-10, 10)``. Resolution must be supplied in the units of the
-       output CRS, so they are commonly in meters for *Projected* and in degrees for
-       *Geographic* CRSs. ``resolution=10`` is equivalent to ``resolution=(-10, 10)``.
+       Set resolution of output in units of the output CRS. This can be a single float, in which
+       case pixels are assumed to be square with ``Y`` axis flipped. To specify non-square or
+       non-flipped pixels use :py:func:`odc.geo.resxy_` or :py:func:`odc.geo.resyx_`.
+       ``resolution=10`` is equivalent to ``resolution=odc.geo.resxy_(10, -10)``.
+
+       Resolution must be supplied in the units of the output CRS. Units are commonly meters
+       for *Projected* and degrees for *Geographic* CRSs.
 
     :param bbox:
        Specify bounding box in Lon/Lat. ``[min(lon), min(lat), max(lon), max(lat)]``

--- a/odc/stac/_model.py
+++ b/odc/stac/_model.py
@@ -504,6 +504,9 @@ class RasterLoadParams:
     resampling: str = "nearest"
     """Resampling method to use."""
 
+    fail_on_error: bool = True
+    """Quit on the first error or continue."""
+
     @staticmethod
     def same_as(src: Union[RasterBandMetadata, RasterSource]) -> "RasterLoadParams":
         """Construct from source object."""

--- a/odc/stac/_version.py
+++ b/odc/stac/_version.py
@@ -1,2 +1,2 @@
 """version information only."""
-__version__ = "0.3.3"
+__version__ = "0.3.4"


### PR DESCRIPTION
Adds new argument `odc.stac.load(..., fail_on_error=False)` #99, when set to `False` it will skip over IO errors. Errors are logged, but at the moment there is no programmatic way to get a list of failed files.

This PR also includes updates to github action versions and rework of notebook rendering action, instead of using docker it now builds binder environment to execute notebooks in.


