### PR TITLE
fix: handle missing bands when constructing Dask graph

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,10 +66,8 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         if: steps.conda_cache.outputs.cache-hit != 'true'
         with:
-          channels: conda-forge,defaults
-          channel-priority: true
-          activate-environment: ""
-          mamba-version: "*"
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
           use-mamba: true
 
       - name: Dump Conda Environment Info
@@ -110,10 +108,8 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         if: steps.binder_cache.outputs.cache-hit != 'true'
         with:
-          channels: conda-forge
-          channel-priority: true
-          activate-environment: ""
-          mamba-version: "*"
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
           use-mamba: true
 
       - name: Dump Conda Environment Info

--- a/odc/stac/_load.py
+++ b/odc/stac/_load.py
@@ -131,11 +131,17 @@ class _DaskGraphBuilder:
         md_key = f"md-{name}-{tk}"
         shape_in_blocks = (shape[0], *self.gbt.shape.yx)
         for idx, item in enumerate(self.items):
-            dsk[md_key, idx] = item[name]
+            band = item.get(name, None)
+            if band is not None:
+                dsk[md_key, idx] = band
 
         for ti, yi, xi in np.ndindex(shape_in_blocks):
             tyx_idx = (ti, yi, xi)
-            srcs = [(md_key, idx) for idx in self.tyx_bins.get(tyx_idx, [])]
+            srcs = [
+                (md_key, idx)
+                for idx in self.tyx_bins.get(tyx_idx, [])
+                if (md_key, idx) in dsk
+            ]
             dsk[band_key, ti, yi, xi] = (
                 _dask_loader_tyx,
                 srcs,


### PR DESCRIPTION
Not all `(item, band)` pairs are valid, STAC item can have missing assets. This case is handled in direct load case, but was not when using Dask (#102).

Closes #102 