### PR TITLE
fix: multi band asset parsing of band index #107

### DIFF
--- a/odc/stac/_mdtools.py
+++ b/odc/stac/_mdtools.py
@@ -638,7 +638,7 @@ def parse_item(
         return grid
 
     for bk, meta in template.bands.items():
-        asset_name, _ = bk
+        asset_name, band_idx = bk
         asset = _assets.get(asset_name)
         if asset is None:
             continue
@@ -652,7 +652,7 @@ def parse_item(
                 f"Can not determine absolute path for band: {asset_name}"
             )  # pragma: no cover (https://github.com/stac-utils/pystac/issues/754)
 
-        bands[bk] = RasterSource(uri=uri, geobox=geobox, meta=meta)
+        bands[bk] = RasterSource(uri=uri, band=band_idx, geobox=geobox, meta=meta)
 
     md = item.common_metadata
     return ParsedItem(

--- a/odc/stac/eo3/_eo3converter.py
+++ b/odc/stac/eo3/_eo3converter.py
@@ -80,8 +80,8 @@ def _to_product(md: RasterCollectionMetadata) -> DatasetType:
         }
         if aliases is not None:
             doc["aliases"] = aliases
-        if idx > 0:
-            doc["band"] = idx + 1  # one based in datacube
+        if idx > 1:
+            doc["band"] = idx
         return doc
 
     # drop ambigous aliases

--- a/tests/data/S2B_MSIL2A_20190629T212529_R043_T06VVN_20201006T080531_raster_ext.json
+++ b/tests/data/S2B_MSIL2A_20190629T212529_R043_T06VVN_20201006T080531_raster_ext.json
@@ -669,7 +669,11 @@
         -10.0,
         6800040.0
       ],
-      "raster:bands": [{"nodata": 0, "data_type": "uint8"}],
+      "raster:bands": [
+        {"data_type": "uint8"},
+        {"data_type": "uint8"},
+        {"data_type": "uint8"}
+      ],
       "roles": [
         "data"
       ]

--- a/tests/test_eo3converter.py
+++ b/tests/test_eo3converter.py
@@ -23,6 +23,7 @@ def test_infer_product_collection(
     assert has_raster_ext(sentinel_stac_collection) is True
     product = infer_dc_product(sentinel_stac_collection)
     assert product.measurements["SCL"].dtype == "uint8"
+    assert product.measurements["SCL"].get("band") is None
     # check aliases from eo extension
     assert product.canonical_measurement("red") == "B04"
     assert product.canonical_measurement("green") == "B03"
@@ -91,12 +92,17 @@ def test_infer_product_raster_ext(sentinel_stac_ms_with_raster_ext: pystac.item.
 
     assert product.measurements["SCL"].dtype == "uint8"
     assert product.measurements["visual"].dtype == "uint8"
+    assert product.measurements["visual_2"].dtype == "uint8"
+    assert product.measurements["visual_2"].band == 2
+    assert product.measurements["visual_3"].band == 3
 
     # check aliases from eo extension
     assert product.canonical_measurement("red") == "B04"
     assert product.canonical_measurement("green") == "B03"
     assert product.canonical_measurement("blue") == "B02"
-    assert set(product._md.band2grid) == set(product.measurements)
+    assert set(product._md.band2grid) | set(["visual_2", "visual_3"]) == set(
+        product.measurements
+    )
 
 
 def test_item_to_ds(sentinel_stac_ms: pystac.item.Item):

--- a/tests/test_mdtools.py
+++ b/tests/test_mdtools.py
@@ -266,6 +266,18 @@ def test_parse_item(sentinel_stac_ms: pystac.item.Item):
     assert xx.get("B01", None) is None
 
 
+def test_parse_item_raster_ext(sentinel_stac_ms_with_raster_ext: pystac.item.Item):
+    item = sentinel_stac_ms_with_raster_ext
+    parsed = parse_item(item)
+    assert parsed[("visual", 2)].band == 2
+    assert parsed["visual.2"].band == 2
+    assert parsed[("visual", 3)] is parsed["visual.3"]
+
+    for (band, idx), b in parsed.bands.items():
+        assert idx == b.band
+        assert band in S2_ALL_BANDS
+
+
 @pytest.mark.xfail
 def test_parse_no_absolute_href(relative_href_only: pystac.item.Item):
     # Currently pystac never returns `None` from attached asset


### PR DESCRIPTION
- Band index was always set to 1 on the parsed item
- Conversion to datacube dataset also had an issue with band index: it was adding +1 to an already 1 based index.

Closes #107 