### PR TITLE
Expand raster data detection

### DIFF
--- a/odc/stac/_mdtools.py
+++ b/odc/stac/_mdtools.py
@@ -304,6 +304,7 @@ def _group_geoboxes(
     geoboxes: Dict[str, GeoBox]
 ) -> Tuple[Dict[str, GeoBox], Dict[str, str]]:
     # pylint: disable=too-many-locals
+    assert len(geoboxes) > 0
 
     def gbox_name(geobox: GeoBox) -> str:
         gsd = geobox_gsd(geobox)
@@ -343,6 +344,9 @@ def _group_geoboxes(
 
 
 def band2grid_from_gsd(assets: Dict[str, pystac.asset.Asset]) -> Dict[str, str]:
+    if not assets:
+        return {}
+
     grids: Dict[float, List[str]] = {}
     for name, asset in assets.items():
         gsd = asset.common_metadata.gsd

--- a/tests/test_eo3converter.py
+++ b/tests/test_eo3converter.py
@@ -217,8 +217,8 @@ def test_partial_proj(partial_proj_stac):
 
 
 def test_noassets_case(no_bands_stac):
-    with pytest.raises(ValueError):
-        list(stac2ds([no_bands_stac]))
+    (ds,) = stac2ds([no_bands_stac])
+    assert len(ds.measurements) == 0
 
 
 def test_old_imports():

--- a/tests/test_mdtools.py
+++ b/tests/test_mdtools.py
@@ -208,8 +208,8 @@ def test_extract_md(sentinel_stac_ms: pystac.item.Item):
 
 
 def test_noassets_case(no_bands_stac):
-    with pytest.raises(ValueError):
-        _ = extract_collection_metadata(no_bands_stac)
+    md = extract_collection_metadata(no_bands_stac)
+    assert len(md.bands) == 0
 
 
 def test_extract_md_raster_ext(sentinel_stac_ms_with_raster_ext: pystac.item.Item):


### PR DESCRIPTION
- Accept `application/[x-]{hdf,netcdf,zarr}` media types as raster data
- Handle case when no asset is classified as raster data

Part of the fix for #114 