### PR TITLE
fix: band resolution for multi-band assets

### DIFF
--- a/odc/stac/_model.py
+++ b/odc/stac/_model.py
@@ -125,7 +125,9 @@ class RasterCollectionMetadata(Mapping[Union[str, BandKey], RasterBandMetadata])
 
     def _norm_key(self, k: BandKey) -> str:
         asset, idx = k
-        if idx == 1:
+
+        # if single band asset it's just asset name
+        if idx == 1 and (asset, 2) not in self.bands:
             return asset
 
         # if any alias references this key as first choice return that

--- a/odc/stac/_version.py
+++ b/odc/stac/_version.py
@@ -1,2 +1,2 @@
 """version information only."""
-__version__ = "0.3.5"
+__version__ = "0.3.6"

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -133,7 +133,7 @@ def test_collection(collection_ab: RasterCollectionMetadata):
 def test_collection_allbands():
     xx = mk_parsed_item([b_("a.1"), b_("a.2"), b_("a.3")])
     md = xx.collection
-    assert md.all_bands == ["a", "a.2", "a.3"]
+    assert md.all_bands == ["a.1", "a.2", "a.3"]
 
     md.aliases["AA"] = [("a", 2)]
     md.aliases["AAA"] = [("a", 3)]
@@ -142,7 +142,7 @@ def test_collection_allbands():
 
     # expect aliases to be used for all_band when multi-band
     # assets have unique aliases
-    assert md.all_bands == ["a", "AA", "AAA"]
+    assert md.all_bands == ["a.1", "AA", "AAA"]
     assert md.canonical_name("a.2") == "AA"
     assert md.canonical_name("AA") == "AA"
     assert md.canonical_name("a.3") == "AAA"


### PR DESCRIPTION
Band name is now:

- Asset name when only one band per asset
- Alias if set and unique
- f"{asset}.{idx}" when multi-band and no aliases defined

Closes #113 