### PR TITLE
Close some long standing issues

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -426,7 +426,7 @@ jobs:
       - name: Deploy to Netlify
         id: netlify
         if: github.event_name == 'pull_request'
-        uses: nwtgck/actions-netlify@v1.0
+        uses: nwtgck/actions-netlify@v2
         with:
           production-branch: "main"
           publish-dir: "docs/_build/html"
@@ -440,7 +440,7 @@ jobs:
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
 
       - name: Print Notice
-        uses: actions/github-script@v5
+        uses: actions/github-script@v6
         if: github.event_name == 'pull_request'
         env:
           NETLIFY_URL: ${{ steps.netlify.outputs.deploy-url }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -288,7 +288,7 @@ jobs:
         if: |
           github.repository == 'opendatacube/odc-stac'
 
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
           fail_ci_if_error: false
           verbose: false

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -22,6 +22,7 @@ dependencies:
   # JupyterLab
   - jupytext
   - jupyter-server-proxy
+  - ipykernel
   - matplotlib
   - ipympl
   - dask

--- a/odc/stac/_load.py
+++ b/odc/stac/_load.py
@@ -85,7 +85,7 @@ class _LoadChunkTask:
     @property
     def dst_gbox(self) -> GeoBox:
         _, y, x = self.idx_tyx
-        return self.gbt[y, x]
+        return cast(GeoBox, self.gbt[y, x])
 
 
 class _DaskGraphBuilder:
@@ -665,7 +665,7 @@ def _dask_loader_tyx(
     env: Dict[str, Any],
 ):
     assert cfg.dtype is not None
-    gbox = gbt[iyx]
+    gbox = cast(GeoBox, gbt[iyx])
     chunk = np.empty(gbox.shape.yx, dtype=cfg.dtype)
     with rio_env(**env):
         return _fill_2d_slice(srcs, gbox, cfg, chunk)[np.newaxis]

--- a/odc/stac/_mdtools.py
+++ b/odc/stac/_mdtools.py
@@ -514,10 +514,11 @@ class _CMDAssembler:
         if bm is not None:
             return {(name, 1): copy(bm)}
 
-        return {
-            (name, idx + 1): bm
-            for idx, bm in enumerate(band_metadata(asset, c.band_defaults))
-        }
+        bm = c.band_cfg.get(f"{name}.*", None)
+        if bm is None:
+            bm = c.band_defaults
+
+        return {(name, idx + 1): bm for idx, bm in enumerate(band_metadata(asset, bm))}
 
     def _bootstrap(self, item: pystac.item.Item):
         """Called on the very first item only."""

--- a/odc/stac/_version.py
+++ b/odc/stac/_version.py
@@ -1,2 +1,2 @@
 """version information only."""
-__version__ = "0.3.6"
+__version__ = "0.3.7"


### PR DESCRIPTION
- Closes #125 
- Closes #81 
- Closes #123
- Maintenance
  - type annotations (`odc-geo` changes)
  - binder environment
  - Config overrides in the form `{asset_name}.*` apply to all bands of a given asset, e.g. `"visual.*": {"dtype": "uint8"}`

