### PR TITLE
Use `has_extension` rather than deprecated `validate_has_extension`

### DIFF
--- a/odc/stac/_mdtools.py
+++ b/odc/stac/_mdtools.py
@@ -178,7 +178,7 @@ def has_raster_ext(item: Union[pystac.item.Item, pystac.collection.Collection]) 
     return any(
         ext_name.startswith("https://stac-extensions.github.io/raster/")
         for ext_name in item.stac_extensions
-        )
+    )
 
 
 def has_proj_data(asset: pystac.asset.Asset) -> bool:

--- a/odc/stac/_mdtools.py
+++ b/odc/stac/_mdtools.py
@@ -159,11 +159,10 @@ def has_proj_ext(item: Union[pystac.item.Item, pystac.collection.Collection]) ->
     if ProjectionExtension.has_extension(item):
         return True
     # can remove this block once pystac 1.9.0 is the min supported version
-    else:
-        return any(
-            ext_name.startswith("https://stac-extensions.github.io/projection/")
-            for ext_name in item.stac_extensions
-        )
+    return any(
+        ext_name.startswith("https://stac-extensions.github.io/projection/")
+        for ext_name in item.stac_extensions
+    )
 
 
 def has_raster_ext(item: Union[pystac.item.Item, pystac.collection.Collection]) -> bool:
@@ -176,10 +175,9 @@ def has_raster_ext(item: Union[pystac.item.Item, pystac.collection.Collection]) 
     if RasterExtension.has_extension(item):
         return True
     # can remove this block once pystac 1.9.0 is the min supported version
-    else:
-        return any(
-            ext_name.startswith("https://stac-extensions.github.io/raster/")
-            for ext_name in item.stac_extensions
+    return any(
+        ext_name.startswith("https://stac-extensions.github.io/raster/")
+        for ext_name in item.stac_extensions
         )
 
 

--- a/odc/stac/_mdtools.py
+++ b/odc/stac/_mdtools.py
@@ -156,7 +156,14 @@ def has_proj_ext(item: Union[pystac.item.Item, pystac.collection.Collection]) ->
     :returns: ``True`` if PROJ extension is enabled
     :returns: ``False`` if no PROJ extension was found
     """
-    return ProjectionExtension.has_extension(item)
+    if ProjectionExtension.has_extension(item):
+        return True
+    # can remove this block once pystac 1.9.0 is the min supported version
+    else:
+        return any(
+            ext_name.startswith("https://stac-extensions.github.io/projection/")
+            for ext_name in item.stac_extensions
+        )
 
 
 def has_raster_ext(item: Union[pystac.item.Item, pystac.collection.Collection]) -> bool:
@@ -166,7 +173,14 @@ def has_raster_ext(item: Union[pystac.item.Item, pystac.collection.Collection]) 
     :returns: ``True`` if Raster extension is enabled
     :returns: ``False`` if no Raster extension was found
     """
-    return RasterExtension.has_extension(item)
+    if RasterExtension.has_extension(item):
+        return True
+    # can remove this block once pystac 1.9.0 is the min supported version
+    else:
+        return any(
+            ext_name.startswith("https://stac-extensions.github.io/raster/")
+            for ext_name in item.stac_extensions
+        )
 
 
 def has_proj_data(asset: pystac.asset.Asset) -> bool:

--- a/odc/stac/_mdtools.py
+++ b/odc/stac/_mdtools.py
@@ -153,31 +153,20 @@ def has_proj_ext(item: Union[pystac.item.Item, pystac.collection.Collection]) ->
     """
     Check if STAC Item or Collection has projection extension.
 
-    :returns: ``True`` if PROJ exetension is enabled
+    :returns: ``True`` if PROJ extension is enabled
     :returns: ``False`` if no PROJ extension was found
     """
-    try:
-        ProjectionExtension.validate_has_extension(item, add_if_missing=False)
-        return True
-    except pystac.errors.ExtensionNotImplemented:
-        return False
+    return ProjectionExtension.has_extension(item)
 
 
 def has_raster_ext(item: Union[pystac.item.Item, pystac.collection.Collection]) -> bool:
     """
-    Check if STAC Item/Collection have EOExtension.
+    Check if STAC Item/Collection have RasterExtension.
 
-    :returns: ``True`` if Raster exetension is enabled
-    :returns: ``False`` if no Rasetr extension was found
+    :returns: ``True`` if Raster extension is enabled
+    :returns: ``False`` if no Raster extension was found
     """
-    try:
-        RasterExtension.validate_has_extension(item, add_if_missing=False)
-        return True
-    except pystac.errors.ExtensionNotImplemented:
-        return any(
-            ext_name.startswith("https://stac-extensions.github.io/raster/")
-            for ext_name in item.stac_extensions
-        )
+    return RasterExtension.has_extension(item)
 
 
 def has_proj_data(asset: pystac.asset.Asset) -> bool:


### PR DESCRIPTION
With pystac 1.9 there `validate_has_extension` is deprecated, so there was a warning cropping up. This seemed like a simpler solution anyways.