### PR TITLE
Fixes for auto computation of output pixel grids

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,14 +9,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         id: wheels_cache
         with:
           path: ./wheels
@@ -55,15 +55,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         id: conda_cache
         with:
           path: /tmp/test_env
           key: ${{ runner.os }}-test-env-py310-${{ hashFiles('tests/test-env-py310.yml') }}
 
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         if: steps.conda_cache.outputs.cache-hit != 'true'
         with:
           miniforge-variant: Mambaforge
@@ -97,15 +97,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         id: binder_cache
         with:
           path: /tmp/binder_env
           key: ${{ runner.os }}-binder-env-${{ hashFiles('binder/environment.yml') }}
 
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         if: steps.binder_cache.outputs.cache-hit != 'true'
         with:
           miniforge-variant: Mambaforge
@@ -142,9 +142,9 @@ jobs:
       - build-test-env-base
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Get Conda Environment from Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: conda_cache
         with:
           path: /tmp/test_env
@@ -167,9 +167,9 @@ jobs:
       - build-test-env-base
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Get Conda Environment from Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: conda_cache
         with:
           path: /tmp/test_env
@@ -196,9 +196,9 @@ jobs:
       - build-test-env-base
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Get Conda Environment from Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: conda_cache
         with:
           path: /tmp/test_env
@@ -217,10 +217,10 @@ jobs:
   test-without-botocore:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.8
           cache: "pip"
@@ -250,10 +250,10 @@ jobs:
       - run-black-check
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Get Conda Environment from Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: conda_cache
         with:
           path: /tmp/test_env
@@ -302,17 +302,17 @@ jobs:
       - build-wheels
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Get Wheels from Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: wheels_cache
         with:
           path: ./wheels
           key: wheels-${{ github.sha }}
 
       - name: Get Conda Environment from Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: conda_cache
         with:
           path: /tmp/test_env
@@ -349,9 +349,9 @@ jobs:
       - build-binder-env
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         id: nb_cache
         with:
           path: docs/notebooks
@@ -359,7 +359,7 @@ jobs:
 
       - name: Get Conda Environment from Cache
         if: steps.nb_cache.outputs.cache-hit != 'true'
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: conda_cache
         with:
           path: /tmp/binder_env
@@ -392,17 +392,17 @@ jobs:
       - build-notebooks
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Get Rendered Notebooks
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: nb_cache
         with:
           path: docs/notebooks
           key: docs-notebooks-${{ hashFiles('notebooks/*.py') }}
 
       - name: Get Conda Environment from Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: conda_cache
         with:
           path: /tmp/test_env

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -24,6 +24,28 @@ odc.stac
    extract_collection_metadata
    output_geobox
 
+odc.stac.ParsedItem
+*******************
+
+.. currentmodule:: odc.stac
+.. autosummary::
+   :toctree: _api/
+
+   ParsedItem
+   ParsedItem.assets
+   ParsedItem.crs
+   ParsedItem.geoboxes
+   ParsedItem.image_geometry
+   ParsedItem.resolve_bands
+   ParsedItem.safe_geometry
+   ParsedItem.solar_date_at
+   ParsedItem.strip
+
+   RasterBandMetadata
+   RasterCollectionMetadata
+   RasterLoadParams
+   RasterSource
+
 odc.stac.bench
 **************
 

--- a/docs/samples/save-cog-from-stac.py
+++ b/docs/samples/save-cog-from-stac.py
@@ -17,6 +17,7 @@ pip install odc-stac==0.3.0rc1 tqdm planetary_computer pystac-client
 ```
 
 """
+
 import planetary_computer
 import pystac_client
 from affine import Affine

--- a/odc/stac/__init__.py
+++ b/odc/stac/__init__.py
@@ -1,4 +1,5 @@
 """STAC Item -> ODC Dataset[eo3]."""
+
 from ._version import __version__  # isort:skip  this has to be 1st import
 from ._load import load
 from ._mdtools import (

--- a/odc/stac/__init__.py
+++ b/odc/stac/__init__.py
@@ -4,10 +4,11 @@ from ._version import __version__  # isort:skip  this has to be 1st import
 from ._load import load
 from ._mdtools import (
     ConversionConfig,
-    parse_item,
-    parse_items,
+    ParsedItem,
     extract_collection_metadata,
     output_geobox,
+    parse_item,
+    parse_items,
 )
 from ._model import (
     RasterBandMetadata,
@@ -21,6 +22,7 @@ stac_load = load
 
 
 __all__ = (
+    "ParsedItem",
     "RasterBandMetadata",
     "RasterCollectionMetadata",
     "RasterLoadParams",

--- a/odc/stac/_dask.py
+++ b/odc/stac/_dask.py
@@ -1,6 +1,7 @@
 """
 Various Dask helpers.
 """
+
 from typing import Any, Callable, Hashable, Iterator, MutableMapping, Optional, Tuple
 
 from dask.base import tokenize

--- a/odc/stac/_load.py
+++ b/odc/stac/_load.py
@@ -1,4 +1,5 @@
 """stac.load - dc.load from STAC Items."""
+
 from __future__ import annotations
 
 import dataclasses
@@ -69,8 +70,7 @@ class MkArray(Protocol):
         dtype: DTypeLike,
         /,
         name: Hashable,
-    ) -> Any:
-        ...  # pragma: no cover
+    ) -> Any: ...  # pragma: no cover
 
 
 @dataclasses.dataclass(frozen=True)

--- a/odc/stac/_mdtools.py
+++ b/odc/stac/_mdtools.py
@@ -720,6 +720,11 @@ def parse_item(
 def parse_items(
     items: Iterable[pystac.item.Item], cfg: Optional[ConversionConfig] = None
 ) -> Iterator[ParsedItem]:
+    """
+    Parse sequence of STAC Items into internal representation.
+
+    Exposed for debugging purposes.
+    """
     proc_cache: Dict[str, _CMDAssembler] = {}
 
     for item in items:
@@ -847,6 +852,11 @@ def output_geobox(
     x: Optional[Tuple[float, float]] = None,
     y: Optional[Tuple[float, float]] = None,
 ) -> Optional[GeoBox]:
+    """
+    Used to compute output geobox from load parameters.
+
+    Exposed at top-level for debugging.
+    """
     # pylint: disable=too-many-locals,too-many-branches,too-many-statements,too-many-return-statements
 
     # geobox, like --> GeoBox

--- a/odc/stac/_model.py
+++ b/odc/stac/_model.py
@@ -281,7 +281,7 @@ class ParsedItem(Mapping[Union[BandKey, str], RasterSource]):
 
     def geoboxes(self, bands: BandQuery = None) -> Tuple[GeoBox, ...]:
         """
-        Unique ``GeoBox``s, highest resolution first.
+        Unique ``GeoBox`` s, highest resolution first.
 
         :param bands: which bands to consider, default is all
         """
@@ -314,6 +314,9 @@ class ParsedItem(Mapping[Union[BandKey, str], RasterSource]):
         crs: MaybeCRS = Unset(),
         bands: BandQuery = None,
     ) -> Optional[Geometry]:
+        """
+        Extract footprint of a given band(s) from proj metadata in a given projection.
+        """
         if isinstance(crs, Unset):
             crs = None
 
@@ -403,7 +406,7 @@ class ParsedItem(Mapping[Union[BandKey, str], RasterSource]):
         - datetime if set
         - start_datetime if set
         - end_datetime if set
-        - raise ValueError otherwise
+        - ``raise ValueError`` otherwise
         """
         for ts in [self.datetime, *self.datetime_range]:
             if ts is not None:

--- a/odc/stac/_utils.py
+++ b/odc/stac/_utils.py
@@ -1,6 +1,7 @@
 """
 Generic tools with only standard lib dependencies.
 """
+
 from concurrent.futures import ThreadPoolExecutor
 from typing import Callable, Iterable, Iterator, Sized, TypeVar, Union
 

--- a/odc/stac/_version.py
+++ b/odc/stac/_version.py
@@ -1,2 +1,3 @@
 """version information only."""
+
 __version__ = "0.3.8"

--- a/odc/stac/_version.py
+++ b/odc/stac/_version.py
@@ -1,3 +1,3 @@
 """version information only."""
 
-__version__ = "0.3.8"
+__version__ = "0.3.9"

--- a/odc/stac/bench/__init__.py
+++ b/odc/stac/bench/__init__.py
@@ -1,4 +1,5 @@
 """Benchmarking tools."""
+
 from ._prepare import SAMPLE_SITES, dump_site
 from ._report import load_results
 from ._run import (

--- a/odc/stac/bench/__main__.py
+++ b/odc/stac/bench/__main__.py
@@ -1,4 +1,5 @@
 """Run main."""
+
 from ._cli import main
 
 main()

--- a/odc/stac/bench/_cli.py
+++ b/odc/stac/bench/_cli.py
@@ -1,4 +1,5 @@
 """CLI app for benchmarking."""
+
 import json
 from datetime import datetime
 from time import sleep

--- a/odc/stac/bench/_prepare.py
+++ b/odc/stac/bench/_prepare.py
@@ -1,4 +1,5 @@
 """Utilities for benchmarking."""
+
 import json
 from pathlib import Path
 from typing import Any, Dict

--- a/odc/stac/bench/_report.py
+++ b/odc/stac/bench/_report.py
@@ -1,4 +1,5 @@
 """Helper methods for benchmark reporting."""
+
 import glob
 import pickle
 from typing import Any, Dict, Iterable, Iterator, Union

--- a/odc/stac/bench/_run.py
+++ b/odc/stac/bench/_run.py
@@ -1,4 +1,5 @@
 """Utilities for benchmarking."""
+
 import importlib
 import json
 import pickle

--- a/odc/stac/eo3/__init__.py
+++ b/odc/stac/eo3/__init__.py
@@ -3,6 +3,7 @@ Datacube metadata generation from STAC.
 
 This only imports if datacube is installed.
 """
+
 from ._eo3converter import infer_dc_product, stac2ds
 
 __all__ = (

--- a/odc/stac/testing/fixtures.py
+++ b/odc/stac/testing/fixtures.py
@@ -1,6 +1,7 @@
 """
 Test fixture construction utilities.
 """
+
 import atexit
 import os
 import pathlib

--- a/odc/stac/testing/stac.py
+++ b/odc/stac/testing/stac.py
@@ -1,6 +1,7 @@
 """
 Making STAC items for testing.
 """
+
 from datetime import datetime, timezone
 
 import pystac.asset

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 """
 Test for SQS to DC tool
 """
+
 import json
 import os
 from pathlib import Path

--- a/tests/test_mdtools.py
+++ b/tests/test_mdtools.py
@@ -323,9 +323,12 @@ def test_auto_load_params(parsed_item_s2: ParsedItem):
     assert len(xx.geoboxes()) == 3
     crs = xx.geoboxes()[0].crs
 
-    _10m = xx["B02"].geobox.resolution
-    _20m = xx["B05"].geobox.resolution
-    _60m = xx["B01"].geobox.resolution
+    _gbox_10m = xx["B02"].geobox
+    _gbox_20m = xx["B05"].geobox
+    _gbox_60m = xx["B01"].geobox
+    _10m = _gbox_10m.resolution
+    _20m = _gbox_20m.resolution
+    _60m = _gbox_60m.resolution
     _edge = AnchorEnum.EDGE
 
     assert _10m.xy == (10, -10)
@@ -333,12 +336,17 @@ def test_auto_load_params(parsed_item_s2: ParsedItem):
     assert _60m.xy == (60, -60)
 
     assert _auto_load_params([]) is None
-    assert _auto_load_params([xx]) == (crs, _10m, _edge)
-    assert _auto_load_params([xx] * 3) == (crs, _10m, _edge)
+    assert _auto_load_params([xx]) == (crs, _10m, _edge, _gbox_10m)
+    assert _auto_load_params([xx] * 3) == (crs, _10m, _edge, _gbox_10m)
 
-    assert _auto_load_params([xx], ["B01"]) == (crs, _60m, _edge)
-    assert _auto_load_params([xx] * 3, ["B01", "B05", "B06"]) == (crs, _20m, _edge)
-    assert _auto_load_params([xx] * 3, ["B01", "B04"]) == (crs, _10m, _edge)
+    assert _auto_load_params([xx], ["B01"]) == (crs, _60m, _edge, _gbox_60m)
+    assert _auto_load_params([xx] * 3, ["B01", "B05", "B06"]) == (
+        crs,
+        _20m,
+        _edge,
+        _gbox_20m,
+    )
+    assert _auto_load_params([xx] * 3, ["B01", "B04"]) == (crs, _10m, _edge, _gbox_10m)
 
 
 def test_norm_geom(gpd_iso3):
@@ -600,6 +608,7 @@ def test_most_common_gbox():
         gbox.crs,
         gbox.resolution,
         AnchorEnum.EDGE,
+        None,
     )
     # not enough consensus for anchor
     # fallback to EDGE aligned
@@ -615,6 +624,7 @@ def test_most_common_gbox():
         gbox.crs,
         gbox.resolution,
         AnchorEnum.EDGE,
+        None,
     )
 
     # CENTER
@@ -627,4 +637,5 @@ def test_most_common_gbox():
         gbox.crs,
         gbox.resolution,
         AnchorEnum.CENTER,
+        None,
     )


### PR DESCRIPTION
## Fix in output_geobox

- When all requested STAC items share one common GeoBox and the user have not requested specific region, resolution, projection or pixel anchor, then GeoBox defined by STAC item(s) shall be used to load the data.
- Closes #140

## Other Maintenance

- bump GH actions
- apply new version of black to source files