### PR TITLE
Release v0.3.10

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -265,11 +265,6 @@ jobs:
         run: |
           echo "/tmp/test_env/bin" >> $GITHUB_PATH
 
-      - name: Patch odc-geo
-        shell: bash
-        run: |
-          pip install "odc-geo>=0.4.7" 
-
       - name: Install in Edit mode
         shell: bash
         run: |
@@ -327,11 +322,6 @@ jobs:
         shell: bash
         run: |
           echo "/tmp/test_env/bin" >> $GITHUB_PATH
-
-      - name: Patch odc-geo
-        shell: bash
-        run: |
-          pip install "odc-geo>=0.4.7"
 
       - name: Install wheels for testing
         shell: bash

--- a/odc/stac/_version.py
+++ b/odc/stac/_version.py
@@ -1,3 +1,3 @@
 """version information only."""
 
-__version__ = "0.3.10rc3"
+__version__ = "0.3.10"

--- a/tests/test-env-py310.yml
+++ b/tests/test-env-py310.yml
@@ -16,7 +16,7 @@ dependencies:
   - numpy
   - pandas
   - toolz
-  - odc-geo
+  - odc-geo >=0.4.7
   - pystac ==1.9.0
   - dask ==2023.12.0
   - xarray ==2023.12.0


### PR DESCRIPTION
- correct `odc-geo` is on conda-forge now, can remove work-around fix
- release 0.3.10