### PR TITLE
Preserve accessories

### DIFF
--- a/odc/stac/_mdtools.py
+++ b/odc/stac/_mdtools.py
@@ -721,7 +721,7 @@ def parse_item(
         }
         for name in _acc_names
     }
-        
+
     md = item.common_metadata
     return ParsedItem(
         item.id,

--- a/odc/stac/_mdtools.py
+++ b/odc/stac/_mdtools.py
@@ -660,7 +660,6 @@ def parse_item(
     band2grid = template.band2grid
     has_proj = False if template.has_proj is False else has_proj_ext(item)
     _assets = item.assets
-    _acc_names = list(_assets.keys())
 
     _grids: Dict[str, GeoBox] = {}
     bands: Dict[BandKey, RasterSource] = {}
@@ -677,14 +676,13 @@ def parse_item(
         _grids[grid_name] = grid
         return grid
 
+    band_names = []
     for bk, meta in template.meta.bands.items():
         asset_name, band_idx = bk
         asset = _assets.get(asset_name)
         if asset is None:
             continue
-        # the assets that aren't bands should be accessories
-        if asset_name in _acc_names:
-            _acc_names.remove(asset_name)
+        band_names.append(asset_name)
 
         grid_name = band2grid.get(asset_name, "default")
         geobox: Optional[GeoBox] = _get_grid(grid_name, asset) if has_proj else None
@@ -715,7 +713,9 @@ def parse_item(
             driver_data=driver_data,
         )
 
-    accessories = {name: {"path": _assets[name].href} for name in _acc_names}
+    # the assets that aren't bands are accessories
+    acc_names = set(_assets.keys()).difference(set(band_names))
+    accessories = {name: {"path": _assets[name].href} for name in acc_names}
 
     md = item.common_metadata
     return ParsedItem(

--- a/odc/stac/_mdtools.py
+++ b/odc/stac/_mdtools.py
@@ -715,12 +715,7 @@ def parse_item(
             driver_data=driver_data,
         )
 
-    accessories = {
-        name: {
-            "path": _assets[name].href
-        }
-        for name in _acc_names
-    }
+    accessories = {name: {"path": _assets[name].href} for name in _acc_names}
 
     md = item.common_metadata
     return ParsedItem(

--- a/odc/stac/_mdtools.py
+++ b/odc/stac/_mdtools.py
@@ -660,6 +660,7 @@ def parse_item(
     band2grid = template.band2grid
     has_proj = False if template.has_proj is False else has_proj_ext(item)
     _assets = item.assets
+    _acc_names = list(_assets.keys())
 
     _grids: Dict[str, GeoBox] = {}
     bands: Dict[BandKey, RasterSource] = {}
@@ -681,6 +682,9 @@ def parse_item(
         asset = _assets.get(asset_name)
         if asset is None:
             continue
+        # the assets that aren't bands should be accessories
+        if asset_name in _acc_names:
+            _acc_names.remove(asset_name)
 
         grid_name = band2grid.get(asset_name, "default")
         geobox: Optional[GeoBox] = _get_grid(grid_name, asset) if has_proj else None
@@ -711,6 +715,13 @@ def parse_item(
             driver_data=driver_data,
         )
 
+    accessories = {
+        name: {
+            "path": _assets[name].href
+        }
+        for name in _acc_names
+    }
+        
     md = item.common_metadata
     return ParsedItem(
         item.id,
@@ -720,6 +731,7 @@ def parse_item(
         datetime=item.datetime,
         datetime_range=(md.start_datetime, md.end_datetime),
         href=item.get_self_href(),
+        accessories=accessories,
     )
 
 

--- a/odc/stac/eo3/_eo3converter.py
+++ b/odc/stac/eo3/_eo3converter.py
@@ -220,6 +220,7 @@ def _to_dataset(
         "properties": dicttoolz.keymap(
             lambda k: STAC_TO_EO3_RENAMES.get(k, k), properties
         ),
+        "accessories": item.accessories,
         "lineage": {},
     }
 

--- a/odc/stac/model.py
+++ b/odc/stac/model.py
@@ -400,7 +400,11 @@ class ParsedItem(Mapping[BandIdentifier, RasterSource]):
         """
         Copy of self but with stripped bands.
         """
-        return replace(self, bands={k: band.strip() for k, band in self.bands.items()}, accessories={})
+        return replace(
+            self,
+            bands={k: band.strip() for k, band in self.bands.items()},
+            accessories={},
+        )
 
     def assets(self) -> Dict[str, List[RasterSource]]:
         """

--- a/odc/stac/model.py
+++ b/odc/stac/model.py
@@ -226,6 +226,9 @@ class ParsedItem(Mapping[BandIdentifier, RasterSource]):
 
     href: Optional[str] = None
     """Self link from stac item."""
+    
+    accessories: dict[str, Any] = field(default_factory=dict)
+    """Additional assets"""
 
     def geoboxes(self, bands: BandQuery = None) -> Tuple[GeoBox, ...]:
         """

--- a/odc/stac/model.py
+++ b/odc/stac/model.py
@@ -400,7 +400,7 @@ class ParsedItem(Mapping[BandIdentifier, RasterSource]):
         """
         Copy of self but with stripped bands.
         """
-        return replace(self, bands={k: band.strip() for k, band in self.bands.items()})
+        return replace(self, bands={k: band.strip() for k, band in self.bands.items()}, accessories={})
 
     def assets(self) -> Dict[str, List[RasterSource]]:
         """

--- a/odc/stac/model.py
+++ b/odc/stac/model.py
@@ -205,6 +205,7 @@ class ParsedItem(Mapping[BandIdentifier, RasterSource]):
 
     Only includes raster bands of interest.
     """
+
     # pylint: disable=too-many-instance-attributes
 
     id: str

--- a/odc/stac/model.py
+++ b/odc/stac/model.py
@@ -205,6 +205,7 @@ class ParsedItem(Mapping[BandIdentifier, RasterSource]):
 
     Only includes raster bands of interest.
     """
+    # pylint: disable=too-many-instance-attributes
 
     id: str
     """Item id copied from STAC."""
@@ -226,7 +227,7 @@ class ParsedItem(Mapping[BandIdentifier, RasterSource]):
 
     href: Optional[str] = None
     """Self link from stac item."""
-    
+
     accessories: dict[str, Any] = field(default_factory=dict)
     """Additional assets"""
 

--- a/tests/test_mdtools.py
+++ b/tests/test_mdtools.py
@@ -400,6 +400,7 @@ def test_accessories_preserved(ga_landsat_stac: pystac.item.Item):
     assert xx.accessories.get("thumbnail:nbart")
     assert xx.accessories.get("checksum:sha1")
     assert xx.accessories.get("metadata:processor")
+    assert xx.strip().accessories == {}
 
 
 @pytest.fixture

--- a/tests/test_mdtools.py
+++ b/tests/test_mdtools.py
@@ -389,6 +389,19 @@ def test_parse_item_no_proj(sentinel_stac_ms: pystac.item.Item):
     assert _auto_load_params([xx] * 3) is None
 
 
+def test_accessories_preserved(ga_landsat_stac: pystac.item.Item):
+    item0 = ga_landsat_stac
+    item = pystac.Item.from_dict(item0.to_dict())
+
+    md = extract_collection_metadata(item, STAC_CFG)
+
+    xx = parse_item(item, md)
+    assert len(xx.accessories) == 3
+    assert xx.accessories.get("thumbnail:nbart")
+    assert xx.accessories.get("checksum:sha1")
+    assert xx.accessories.get("metadata:processor")
+
+
 @pytest.fixture
 def parsed_item_s2(sentinel_stac_ms: pystac.item.Item):
     (item,) = parse_items([sentinel_stac_ms], STAC_CFG)


### PR DESCRIPTION
See #168
Assume that any assets that are not bands are accessories, and make sure they are captured in the Dataset metadata doc