### PR TITLE
Rename deprecated pystac_client methods to get STAC items and collections

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ odc.stac.load
    catalog = pystac_client.Client.open(...)
    query = catalog.search(...)
    xx = odc.stac.load(
-       query.get_items(),
+       query.items(),
        bands=["red", "green", "blue"],
    )
    xx.red.plot.imshow(col="time")

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -10,7 +10,7 @@ Load STAC :py:class:`pystac.Item`\s into :py:class:`xarray.Dataset`.
    catalog = pystac_client.Client.open(...)
    query = catalog.search(...)
    xx = odc.stac.load(
-       query.get_items(),
+       query.items(),
        bands=["red", "green", "blue"],
        resolution=100,
    )

--- a/docs/samples/save-cog-from-stac.py
+++ b/docs/samples/save-cog-from-stac.py
@@ -41,7 +41,7 @@ items = catalog.search(
     collections=["landsat-8-c2-l2"],
     datetime="2021-07-01T08:00:00Z/2021-07-01T09:00:00Z",
     bbox=(-180, -50, 180, 50),
-).get_all_items()
+).item_collection()
 
 # Compute Polygon of the pass in EPSG:3857
 ls8_pass = geom.unary_union(

--- a/odc/stac/_stac_load.py
+++ b/odc/stac/_stac_load.py
@@ -131,7 +131,7 @@ def load(
        catalog = pystac.Client.open(...)
        query = catalog.search(...)
        xx = odc.stac.load(
-           query.get_items(),
+           query.items(),
            bands=["red", "green", "blue"],
        )
        xx.red.plot.imshow(col="time")
@@ -298,7 +298,7 @@ def load(
        )
 
        xx = stac.load(
-           query.get_items(),
+           query.items(),
            bands=["red", "green", "blue"],
            resolution=100,  # 1/10 of the native 10m resolution
            patch_url=pc.sign,

--- a/odc/stac/bench/_prepare.py
+++ b/odc/stac/bench/_prepare.py
@@ -65,7 +65,7 @@ def dump_site(site: Dict[str, Any], overwrite: bool = False) -> Dict[str, Any]:
     cat = pystac_client.Client.open(api)
     search = cat.search(**search)
     print(f"Query API end-point: {api}")
-    all_features = search.get_all_items_as_dict()
+    all_features = search.item_collection_as_dict()
     all_features["properties"] = dict(
         api=search.url, search=search._parameters  # pylint: disable=protected-access
     )

--- a/tests/notebooks/bench-prep-query.py
+++ b/tests/notebooks/bench-prep-query.py
@@ -55,7 +55,7 @@ search = cat.search(
     bbox=bbox,
 )
 print("Query API end-point")
-all_features = search.get_all_items_as_dict()
+all_features = search.item_collection_as_dict()
 
 all_features["properties"] = dict(url=search.url, query=search._parameters)
 all_features["properties"]


### PR DESCRIPTION
These methods were deprecated since https://github.com/stac-utils/pystac-client/pull/206 in pystac_client v0.4.0 (released Jun 2022):

- `get_items()` -> `items()`
- `get_all_items()` -> `item_collection()`
- `get_all_items_as_dict()` -> `item_collection_as_dict()`

This helps to silence the following warnings:

```python-traceback
/srv/conda/envs/notebook/lib/python3.10/site-packages/pystac_client/item_search.py:834: FutureWarning: get_items() is deprecated, use items() instead
  warnings.warn(

/srv/conda/envs/notebook/lib/python3.10/site-packages/pystac_client/item_search.py:849: FutureWarning: get_all_items() is deprecated, use item_collection() instead.
  warnings.warn(

/srv/conda/envs/notebook/lib/python3.10/site-packages/pystac_client/item_search.py:864: FutureWarning: get_all_items_as_dict() is deprecated, use item_collection_as_dict() instead.
  warnings.warn(
```

.
