### PR TITLE
fix: handle assets with . in the name (#191)

### DIFF
--- a/odc/loader/types.py
+++ b/odc/loader/types.py
@@ -582,11 +582,15 @@ def norm_key(k: BandIdentifier) -> BandKey:
     ("band", i) -> ("band", i)
     "band" -> ("band", 1)
     "band.3" -> ("band", 3)
+    "band.tiff" -> ("band.tiff", 1)
     """
     if isinstance(k, str):
         parts = k.rsplit(".", 1)
         if len(parts) == 2:
-            return parts[0], int(parts[1])
+            try:
+                return parts[0], int(parts[1])
+            except ValueError:
+                return (k, 1)
         return (k, 1)
     return k
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -10,6 +10,7 @@ from odc.loader.types import (
     RasterGroupMetadata,
     RasterLoadParams,
     RasterSource,
+    norm_key,
 )
 from odc.stac import ParsedItem, RasterCollectionMetadata
 from odc.stac.testing.stac import b_, mk_parsed_item
@@ -206,3 +207,17 @@ def test_tokenize(parsed_item_ab: ParsedItem):
     assert tokenize(RasterLoadParams()) == tokenize(RasterLoadParams())
     assert tokenize(RasterLoadParams("uint8")) == tokenize(RasterLoadParams("uint8"))
     assert tokenize(RasterLoadParams("uint8")) != tokenize(RasterLoadParams("uint32"))
+
+
+@pytest.mark.parametrize(
+    "name, expected",
+    [
+        ("a", ("a", 1)),
+        ("a.1", ("a", 1)),
+        ("a.2", ("a", 2)),
+        (("b", 1), ("b", 1)),
+        ("foo.tiff", ("foo.tiff", 1)),
+    ],
+)
+def test_normkey(name, expected):
+    assert norm_key(name) == expected


### PR DESCRIPTION
- closes #191 