### PR TITLE
Use Dask TaskSpec for task creation at source

### DIFF
--- a/odc/loader/_builder.py
+++ b/odc/loader/_builder.py
@@ -24,6 +24,7 @@ from typing import (
 
 import numpy as np
 import xarray as xr
+import dask
 from dask import array as da
 from dask import is_dask_collection
 from dask.array.core import normalize_chunks
@@ -33,6 +34,7 @@ from dask.typing import Key
 from numpy.typing import DTypeLike
 from odc.geo.geobox import GeoBox, GeoBoxBase, GeoboxTiles
 from odc.geo.xr import xr_coords
+from packaging.version import Version
 
 from ._reader import (
     ReaderDaskAdaptor,
@@ -54,6 +56,9 @@ from .types import (
 )
 
 DaskBuilderMode = Literal["mem", "concurrency"]
+
+DASK_VERSION = Version(dask.__version__)
+DASK_GE_20250100 = DASK_VERSION.release >= (2024, 12, 1)
 
 
 class MkArray(Protocol):
@@ -137,14 +142,22 @@ class LoadChunkTask:
     def resolve_sources_dask(
         self, dask_key: str, dsk: Mapping[Key, Any] | None = None
     ) -> list[list[tuple[str, int]]]:
+        if DASK_GE_20250100:
+            from dask._task_spec import TaskRef, List
+
+            klass = TaskRef
+            wrapper = List
+        else:
+            klass = tuple
+            wrapper = list
         if dsk is None:
-            return [[(dask_key, idx) for idx in layer] for layer in self.srcs]
+            return wrapper([wrapper([klass((dask_key, idx)) for idx in layer]) for layer in self.srcs])
 
         # Skip missing sources
-        return [
-            [(dask_key, idx) for idx in layer if (dask_key, idx) in dsk]
+        return wrapper([
+            wrapper([klass((dask_key, idx)) for idx in layer if (dask_key, idx) in dsk])
             for layer in self.srcs
-        ]
+        ])
 
 
 def _default_dask_mode() -> DaskBuilderMode:
@@ -287,12 +300,27 @@ class DaskGraphBuilder:
                     rdr_cache[src_hash] = rdr
 
                 fut = rdr.read(dst_gbox, selection=task.selection, idx=idx)
-                keys_out.append(fut.key)
+                if DASK_GE_20250100:
+                    from dask._task_spec import TaskRef
+                    keys_out.append(TaskRef(fut.key))
+                else:
+                    keys_out.append(fut.key)
                 dsk.update(fut.dask)
 
-            out.append(keys_out)
 
-        return out
+            if DASK_GE_20250100:
+                from dask._task_spec import List
+
+                out.append(List(keys_out))
+            else:
+                out.append(keys_out)
+
+        if DASK_GE_20250100:
+            from dask._task_spec import List
+
+            return List(out)
+        else:
+            return out
 
     def __call__(
         self,
@@ -355,19 +383,39 @@ class DaskGraphBuilder:
         for task in self.load_tasks(name, shape[0]):
             task_key: Key = (band_layer, *task.idx)
             if dask_reader is None:
-                dsk[task_key] = (
-                    _dask_loader_tyx,
-                    task.resolve_sources_dask(open_layer, layers[open_layer]),
-                    gbt_dsk,
-                    quote(task.idx_tyx[1:]),
-                    quote(task.prefix_dims),
-                    quote(task.postfix_dims),
-                    cfg_dsk,
-                    self.rdr,
-                    self.env,
-                    load_state_dsk,
-                    task.selection,
-                )
+                if DASK_GE_20250100:
+                    from dask._task_spec import Task, TaskRef
+
+                    dsk[task_key] = Task(
+                        task_key,
+                        _dask_loader_tyx,
+                        task.resolve_sources_dask(open_layer, layers[open_layer]),
+                        TaskRef(gbt_dsk),
+                        quote(task.idx_tyx[1:]),
+                        quote(task.prefix_dims),
+                        quote(task.postfix_dims),
+                        TaskRef(cfg_dsk),
+                        self.rdr,
+                        self.env,
+                        load_state_dsk,
+                        task.selection,
+                        _data_producer=True,
+                    )
+
+                else:
+                    dsk[task_key] = (
+                        _dask_loader_tyx,
+                        task.resolve_sources_dask(open_layer, layers[open_layer]),
+                        gbt_dsk,
+                        quote(task.idx_tyx[1:]),
+                        quote(task.prefix_dims),
+                        quote(task.postfix_dims),
+                        cfg_dsk,
+                        self.rdr,
+                        self.env,
+                        load_state_dsk,
+                        task.selection,
+                    )
             else:
                 srcs_futures = self._task_futures(
                     task,
@@ -376,15 +424,28 @@ class DaskGraphBuilder:
                     layers[open_layer],
                     rdr_cache=rdr_cache,
                 )
+                if DASK_GE_20250100:
+                    from dask._task_spec import Task
 
-                dsk[task_key] = (
-                    _dask_fuser,
-                    srcs_futures,
-                    task.shape,
-                    dtype,
-                    fill_value,
-                    ydim - 1,
-                )
+                    dsk[task_key] = Task(
+                        task_key,
+                        _dask_fuser,
+                        srcs_futures,
+                        task.shape,
+                        dtype,
+                        fill_value,
+                        ydim - 1,
+                        _data_producer=True,
+                    )
+                else:
+                    dsk[task_key] = (
+                        _dask_fuser,
+                        srcs_futures,
+                        task.shape,
+                        dtype,
+                        fill_value,
+                        ydim - 1,
+                    )
 
         dsk = HighLevelGraph(layers, layer_deps)
         return da.Array(dsk, band_layer, chunks, dtype=dtype, shape=shape)

--- a/odc/loader/_builder.py
+++ b/odc/loader/_builder.py
@@ -58,7 +58,7 @@ from .types import (
 DaskBuilderMode = Literal["mem", "concurrency"]
 
 DASK_VERSION = Version(dask.__version__)
-DASK_GE_20250100 = DASK_VERSION.release >= (2024, 12, 1)
+DASK_GE_20250100 = DASK_VERSION.release >= (2025, 1, 0)
 
 
 class MkArray(Protocol):

--- a/odc/loader/_builder.py
+++ b/odc/loader/_builder.py
@@ -143,7 +143,7 @@ class LoadChunkTask:
         self, dask_key: str, dsk: Mapping[Key, Any] | None = None
     ) -> list[list[tuple[str, int]]]:
         if DASK_GE_20250100:
-            from dask._task_spec import TaskRef, List
+            from dask.task_spec import TaskRef, List
 
             klass = TaskRef
             wrapper = List
@@ -301,7 +301,7 @@ class DaskGraphBuilder:
 
                 fut = rdr.read(dst_gbox, selection=task.selection, idx=idx)
                 if DASK_GE_20250100:
-                    from dask._task_spec import TaskRef
+                    from dask.task_spec import TaskRef
                     keys_out.append(TaskRef(fut.key))
                 else:
                     keys_out.append(fut.key)
@@ -309,14 +309,14 @@ class DaskGraphBuilder:
 
 
             if DASK_GE_20250100:
-                from dask._task_spec import List
+                from dask.task_spec import List
 
                 out.append(List(keys_out))
             else:
                 out.append(keys_out)
 
         if DASK_GE_20250100:
-            from dask._task_spec import List
+            from dask.task_spec import List
 
             return List(out)
         else:
@@ -384,7 +384,7 @@ class DaskGraphBuilder:
             task_key: Key = (band_layer, *task.idx)
             if dask_reader is None:
                 if DASK_GE_20250100:
-                    from dask._task_spec import Task, TaskRef
+                    from dask.task_spec import Task, TaskRef
 
                     dsk[task_key] = Task(
                         task_key,
@@ -425,7 +425,7 @@ class DaskGraphBuilder:
                     rdr_cache=rdr_cache,
                 )
                 if DASK_GE_20250100:
-                    from dask._task_spec import Task
+                    from dask.task_spec import Task
 
                     dsk[task_key] = Task(
                         task_key,


### PR DESCRIPTION
Sorry for this ugly branching in the code :( This can be dropped when the minimum dask version is bumped to 2025.1.0 in the future

We've recently added the TaskSpec implementation in Dask, that helps with defining tasks more clearly. One of the features we added in the January release was that we can now deterministically identify root tasks. This helps us avoid root task overproduction (sorry, all very technical). This overproduction regularly kills the scheduler because it overloads the CPU and lets the worker run out of memory. 

The data_producer=True flag here will avoid this in the future for odc-stac workloads (we saw this quite a few times from users where this completely killed their workload).

([here](https://www.coiled.io/blog/reducing-dask-memory-usage) is a blog post explaining the phenomenon)