### PR TITLE
fix(import) : quote in dask.core #199

### DIFF
--- a/odc/loader/_builder.py
+++ b/odc/loader/_builder.py
@@ -27,7 +27,8 @@ import xarray as xr
 from dask import array as da
 from dask import is_dask_collection
 from dask.array.core import normalize_chunks
-from dask.base import quote, tokenize
+from dask.base import tokenize
+from dask.core import quote
 from dask.highlevelgraph import HighLevelGraph
 from dask.typing import Key
 from numpy.typing import DTypeLike


### PR DESCRIPTION
Hey,
I fix the v0.3.11 (for v0.3.12) : 
I switch the `quote`previously imported via `dask.base` to `dask.core` as suggested here : https://github.com/dask/dask/issues/11843
It would make a usable v0.3.12 version.

Kind regards,
Nicolas