### PR TITLE
Fix deprecated uris warnings

### DIFF
--- a/odc/stac/eo3/_eo3converter.py
+++ b/odc/stac/eo3/_eo3converter.py
@@ -224,7 +224,7 @@ def _to_dataset(
         "lineage": {},
     }
 
-    return Dataset(product, prep_eo3(ds_doc), uris=[item.href if item.href else ""])
+    return Dataset(product, prep_eo3(ds_doc), uri=item.href)
 
 
 def _item_to_ds(


### PR DESCRIPTION
There is at most one uri on
the calling side, so use
the non-deprecated uri parameter.