### PR TITLE
Remove unused type ignores

### DIFF
--- a/odc/stac/_mdtools.py
+++ b/odc/stac/_mdtools.py
@@ -297,7 +297,7 @@ def geobox_gsd(geobox: GeoBox) -> float:
     :param geobox: input :class:`~odc.geo.geobox.GeoBox`
     :returns: Minimum ground sampling distance along X/Y
     """
-    return min(map(abs, [geobox.transform.a, geobox.transform.e]))  # type: ignore
+    return min(map(abs, [geobox.transform.a, geobox.transform.e]))
 
 
 def compute_eo3_grids(

--- a/odc/stac/eo3/_eo3converter.py
+++ b/odc/stac/eo3/_eo3converter.py
@@ -13,12 +13,12 @@ import pystac.asset
 import pystac.collection
 import pystac.errors
 import pystac.item
-from datacube.index.eo3 import prep_eo3  # type: ignore
+from datacube.index.eo3 import prep_eo3
 
 try:
-    from datacube.index.index import default_metadata_type_docs  # type: ignore
+    from datacube.index.index import default_metadata_type_docs
 except ImportError:
-    from datacube.index.abstract import default_metadata_type_docs  # type: ignore
+    from datacube.index.abstract import default_metadata_type_docs
 
 from datacube.model import Dataset, Product, metadata_from_doc
 from odc.geo import CRS

--- a/odc/stac/model.py
+++ b/odc/stac/model.py
@@ -241,7 +241,7 @@ class ParsedItem(Mapping[BandIdentifier, RasterSource]):
         bands = self.collection.normalize_band_query(bands)
 
         def _resolution(g: GeoBox) -> float:
-            return min(g.resolution.map(abs).xy)  # type: ignore
+            return min(g.resolution.map(abs).xy)
 
         # TODO: support other geobox types?
         gbx: Set[GeoBox] = set()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,7 @@ include = [
 python_version = "3.10"
 ignore_missing_imports = true
 allow_redefinition = true
+warn_unused_ignores = true
 plugins = "numpy.typing.mypy_plugin"
 
 [tool.coverage.run]


### PR DESCRIPTION
Remove type ignores that are no longer used, and run mypy with `--warn-unused-ignores` to avoid this happening again.