### PR TITLE
Release 0.4.0rc1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "odc-stac"
 description = "Tooling for converting STAC metadata to ODC data model"
-version = "0.4.0a1"
+version = "0.4.0rc1"
 authors = [
     {name = "Open Data Cube"}
 ]
@@ -31,7 +31,7 @@ classifiers = [
 dependencies = [
     "affine",
     "odc-geo>=0.4.7",
-    "odc-loader>=0.5.0",
+    "odc-loader>=0.5.1",
     "rasterio>=1.0.0,!=1.3.0,!=1.3.1",
     "dask[array]",
     "numpy>=1.20.0",


### PR DESCRIPTION
- bump `odc-loader` dependency to `0.5.1` because of #199 

- closes #199 