### PR TITLE
CI: fix CodeCov reports

### DIFF
--- a/.github/workflows/build-binder.yml
+++ b/.github/workflows/build-binder.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: Build Binder Image
-      uses: jupyterhub/repo2docker-action@0.3
+      uses: jupyterhub/repo2docker-action@69702685940e406c5bc32bc26395bbacda7ec9d3 # 0.21
       id: dkr
       with:
         IMAGE_NAME: kirillodc/odc-stac-binder
@@ -25,7 +25,7 @@ jobs:
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
 
     - name: Print Notice
-      uses: actions/github-script@v5
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
       env:
         DKR: ${{ steps.dkr.outputs.IMAGE_SHA_NAME }}
       with:
@@ -44,7 +44,7 @@ jobs:
           DKR: ${{ steps.dkr.outputs.IMAGE_SHA_NAME }}
 
     - name: Publish environment.yaml artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: environment
         path: /tmp/environment.yaml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.10"
 
@@ -33,7 +33,7 @@ jobs:
           find ./wheels/clean -type f | xargs twine check
 
       - name: Upload wheels as artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: python-wheels
           path: ./wheels/clean/
@@ -43,15 +43,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         id: conda_cache
         with:
           path: /tmp/test_env
           key: ${{ runner.os }}-test-env-py310-${{ hashFiles('tests/test-env-py310.yml') }}
 
-      - uses: conda-incubator/setup-miniconda@v3
+      - uses: conda-incubator/setup-miniconda@835234971496cad1653abb28a638a281cf32541f # v3.2.0
         if: steps.conda_cache.outputs.cache-hit != 'true'
         with:
           miniforge-variant: Miniforge3
@@ -84,15 +84,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         id: binder_cache
         with:
           path: /tmp/binder_env
           key: ${{ runner.os }}-binder-env-${{ hashFiles('binder/environment.yml') }}
 
-      - uses: conda-incubator/setup-miniconda@v3
+      - uses: conda-incubator/setup-miniconda@835234971496cad1653abb28a638a281cf32541f # v3.2.0
         if: steps.binder_cache.outputs.cache-hit != 'true'
         with:
           miniforge-variant: Miniforge3 
@@ -128,9 +128,9 @@ jobs:
       - build-test-env-base
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Get Conda Environment from Cache
-        uses: actions/cache@v4
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         id: conda_cache
         with:
           path: /tmp/test_env
@@ -153,9 +153,9 @@ jobs:
       - build-test-env-base
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Get Conda Environment from Cache
-        uses: actions/cache@v4
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         id: conda_cache
         with:
           path: /tmp/test_env
@@ -185,9 +185,9 @@ jobs:
       - build-test-env-base
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Get Conda Environment from Cache
-        uses: actions/cache@v4
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         id: conda_cache
         with:
           path: /tmp/test_env
@@ -212,10 +212,10 @@ jobs:
       - run-black-check
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Get Conda Environment from Cache
-        uses: actions/cache@v4
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         id: conda_cache
         with:
           path: /tmp/test_env
@@ -250,7 +250,7 @@ jobs:
         if: |
           github.repository == 'opendatacube/odc-stac'
 
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
         with:
           fail_ci_if_error: false
           verbose: false
@@ -264,16 +264,16 @@ jobs:
       - build-wheels
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Download wheels from artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           name: python-wheels
           path: ./wheels/clean
 
       - name: Get Conda Environment from Cache
-        uses: actions/cache@v4
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         id: conda_cache
         with:
           path: /tmp/test_env
@@ -310,9 +310,9 @@ jobs:
       - build-binder-env
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         id: nb_cache
         with:
           path: docs/notebooks
@@ -320,7 +320,7 @@ jobs:
 
       - name: Get Conda Environment from Cache
         if: steps.nb_cache.outputs.cache-hit != 'true'
-        uses: actions/cache@v4
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         id: conda_cache
         with:
           path: /tmp/binder_env
@@ -353,17 +353,17 @@ jobs:
       - build-notebooks
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Get Rendered Notebooks
-        uses: actions/cache@v4
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         id: nb_cache
         with:
           path: docs/notebooks
           key: docs-notebooks-${{ hashFiles('notebooks/*.py') }}
 
       - name: Get Conda Environment from Cache
-        uses: actions/cache@v4
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         id: conda_cache
         with:
           path: /tmp/test_env
@@ -398,7 +398,7 @@ jobs:
       - name: Deploy to Netlify
         id: netlify
         if: github.event_name == 'pull_request'
-        uses: nwtgck/actions-netlify@v2
+        uses: nwtgck/actions-netlify@4cbaf4c08f1a7bfa537d6113472ef4424e4eb654 # v3.0.0
         with:
           production-branch: "develop"
           publish-dir: "docs/_build/html"
@@ -413,7 +413,7 @@ jobs:
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
 
       - name: Print Notice
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         if: github.event_name == 'pull_request'
         env:
           NETLIFY_URL: ${{ steps.netlify.outputs.deploy-url }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -206,7 +206,8 @@ jobs:
 
   test-with-botocore-and-coverage:
     runs-on: ubuntu-latest
-
+    permissions:
+      id-token: write
     needs:
       - build-test-env-base
       - run-black-check
@@ -254,6 +255,7 @@ jobs:
         with:
           fail_ci_if_error: false
           verbose: false
+          use_oidc: true
 
   test-wheels:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -11,16 +11,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       
       - name: Download wheels from artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           name: python-wheels
           path: ./wheels/clean
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.10" 
 

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           conda info
           conda list
-          mamba -V
+          mamba --version
           conda config --show-sources
           conda config --show
           printenv | sort

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -18,15 +18,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         id: binder_cache
         with:
           path: /tmp/binder_env
           key: ${{ runner.os }}-binder-env-${{ hashFiles('binder/environment.yml') }}
 
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@835234971496cad1653abb28a638a281cf32541f # v3.2.0
         if: steps.binder_cache.outputs.cache-hit != 'true'
         with:
           channels: conda-forge
@@ -66,7 +66,7 @@ jobs:
       - build-binder-env
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Config
         id: cfg
@@ -80,7 +80,7 @@ jobs:
           echo "nb-hash=${nb_hash}" >> $GITHUB_OUTPUT
           echo "nb-archive=odc-stac-notebooks-${nb_hash}.tar.gz" >> $GITHUB_OUTPUT
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         id: nb_cache
         with:
           path: ${{ steps.cfg.outputs.nb-dir }}
@@ -88,7 +88,7 @@ jobs:
 
       - name: Get Conda Environment from Cache
         if: steps.nb_cache.outputs.cache-hit != 'true' || github.event.inputs.force == 'true'
-        uses: actions/cache@v4
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         id: conda_cache
         with:
           path: /tmp/binder_env
@@ -127,7 +127,7 @@ jobs:
           tar tzf "${nb_archive}"
 
       - name: Upload results (artifact)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: rendered-notebooks
           path: docs/notebooks


### PR DESCRIPTION
Use an OIDC token to get
code coverage reports
on pull requests.

Also pin the actions by hash
to make it harder to get
compromised if some action
gets compromised.