### PR TITLE
CI: cancel previous jobs on PR updates

### DIFF
--- a/.github/workflows/build-binder.yml
+++ b/.github/workflows/build-binder.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   repo2docker:
+    timeout-minutes: 30
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/build-binder.yml
+++ b/.github/workflows/build-binder.yml
@@ -9,6 +9,12 @@ on:
       - 'binder/**'
       - '.github/workflows/build-binder.yml'
 
+# When a PR is updated, cancel the jobs from the previous version. Merges
+# do not define head_ref, so use run_id to never cancel those jobs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   repo2docker:
     timeout-minutes: 30

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,12 @@ on:
   pull_request:
   push:
 
+# When a PR is updated, cancel the jobs from the previous version. Merges
+# do not define head_ref, so use run_id to never cancel those jobs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build-wheels:
     timeout-minutes: 15

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   build-wheels:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
 
     steps:
@@ -40,6 +41,7 @@ jobs:
           retention-days: 1
 
   build-test-env-base:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
 
     steps:
@@ -81,6 +83,7 @@ jobs:
           mamba env export -p /tmp/test_env
 
   build-binder-env:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
 
     steps:
@@ -123,6 +126,7 @@ jobs:
           mamba env export -p /tmp/binder_env
 
   run-black-check:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     needs:
       - build-test-env-base
@@ -148,6 +152,7 @@ jobs:
           black --check --diff .
 
   run-pylint:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     needs:
       - build-test-env-base
@@ -180,6 +185,7 @@ jobs:
           pylint -v odc
 
   run-mypy:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     needs:
       - build-test-env-base
@@ -205,6 +211,7 @@ jobs:
 
 
   test-with-botocore-and-coverage:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -258,6 +265,7 @@ jobs:
           use_oidc: true
 
   test-wheels:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
 
     needs:
@@ -306,6 +314,7 @@ jobs:
           DASK_TEMPORARY_DIRECTORY: /tmp/dask
 
   build-notebooks:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
 
     needs:
@@ -347,6 +356,7 @@ jobs:
           ls -lh $nb_dir
 
   check-docs:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
 
     needs:

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -3,6 +3,12 @@ name: Publish to PyPI
 on:
   workflow_dispatch:
 
+# When a PR is updated, cancel the jobs from the previous version. Merges
+# do not define head_ref, so use run_id to never cancel those jobs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   publish-pypi:
     if: |

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -7,7 +7,7 @@ jobs:
   publish-pypi:
     if: |
       github.repository == 'opendatacube/odc-stac'
-
+    timeout-minutes: 15
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -15,6 +15,7 @@ on:
 
 jobs:
   build-binder-env:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
 
     steps:
@@ -60,6 +61,7 @@ jobs:
           mamba env export -p /tmp/binder_env
 
   render:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
 
     needs:

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -13,6 +13,12 @@ on:
       - "notebooks/*py"
       - ".github/workflows/render.yml"
 
+# When a PR is updated, cancel the jobs from the previous version. Merges
+# do not define head_ref, so use run_id to never cancel those jobs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build-binder-env:
     timeout-minutes: 15


### PR DESCRIPTION
This avoids clogging the CI machines when one of the quick checks fail and you update the PR to fix that.

Also add a commit that shortens the job timeout in case someone hangs the CI machines.