### PR TITLE
Type annotate type aliases

### DIFF
--- a/odc/stac/_mdtools.py
+++ b/odc/stac/_mdtools.py
@@ -20,6 +20,7 @@ from typing import (
     Sequence,
     Set,
     Tuple,
+    TypeAlias,
     Union,
 )
 
@@ -66,7 +67,7 @@ from .model import (
     RasterCollectionMetadata,
 )
 
-ConversionConfig = Dict[str, Any]
+ConversionConfig: TypeAlias = Dict[str, Any]
 
 EPSG4326 = CRS("EPSG:4326")
 

--- a/odc/stac/_stac_load.py
+++ b/odc/stac/_stac_load.py
@@ -18,6 +18,7 @@ from typing import (
     Optional,
     Sequence,
     Tuple,
+    TypeAlias,
     Union,
     cast,
 )
@@ -44,9 +45,9 @@ from .model import BandQuery, ParsedItem, RasterCollectionMetadata
 DEFAULT_CHUNK_FOR_LOAD = 2048
 """Used to partition load when not using Dask."""
 
-GroupbyCallback = Callable[[pystac.item.Item, ParsedItem, int], Any]
+GroupbyCallback: TypeAlias = Callable[[pystac.item.Item, ParsedItem, int], Any]
 
-Groupby = Union[str, GroupbyCallback]
+Groupby: TypeAlias = Union[str, GroupbyCallback]
 
 
 def _collection(items: Iterable[ParsedItem]) -> RasterCollectionMetadata:

--- a/odc/stac/bench/_run.py
+++ b/odc/stac/bench/_run.py
@@ -7,7 +7,7 @@ from copy import copy
 from dataclasses import dataclass, field
 from time import sleep
 from timeit import default_timer as t_now
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, TypeAlias, Union
 
 import affine
 import distributed
@@ -21,7 +21,7 @@ from odc.geo.xr import ODCExtension
 
 import odc.stac
 
-TimeSample = Tuple[float, float, float]
+TimeSample: TypeAlias = Tuple[float, float, float]
 """(t0, t_finished_submit, t_finished_compute)"""
 
 # pylint: disable=too-many-instance-attributes,too-many-locals,too-many-arguments


### PR DESCRIPTION
This removes yellow lines on type
annotations in PyCharm.