### PR TITLE
Release 0.4.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 dependencies = [
     "affine",
     "odc-geo>=0.4.7",
-    "odc-loader>=0.5.1",
+    "odc-loader>=0.5.1,<0.6.0",
     "rasterio>=1.0.0,!=1.3.0,!=1.3.1",
     "dask[array]",
     "numpy>=1.20.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,15 +10,14 @@ maintainers = [
 ]
 readme = "README.rst"
 license = {text = "Apache License 2.0"}
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 classifiers = [
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Scientific/Engineering :: GIS",
     "Typing :: Typed"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "odc-stac"
 description = "Tooling for converting STAC metadata to ODC data model"
-version = "0.4.0"
+version = "0.4.1"
 authors = [
     {name = "Open Data Cube"}
 ]


### PR DESCRIPTION
@Kirill888 - I'm trying to get the odc-stac/odc-loader release path unblocked.  Going from the minutes of the September 2025 Steering Council meeting and my somewhat shaky memories of the associated conversations, what I think needs to happen is laid out below - please let me know if there's anything additional that needs to happen that I've overlooked or forgotten about.

1. Merge this PR:

   - require odc-loader<0.6.0
   - wind `requires_python` forward to remove support for end-of-lifed Python versions (3.9 end of lifed at the end of October)
   - Update version number in pyproject.toml to 0.4.1
   
   Edit: DONE
 
 2. Do odc-stac 0.4.1 release through Github release interface, ensure it goes to PyPI successfully and apply above requirements changes to the conda feedstock PR.
 
    Edit: DONE
 
 2a. REVISIT: odc-stac pypi upload is broken.  Needs further investigation, but possibly a version mismatch between `upload-artefacts` and `download-artefacts`
 
 3. Do an odc-loader 0.6.0 release through Github release interface, ensure it goes to PyPI successfully and update the conda feedstock PR.

      Edit: DONE
 
 4. Merge odc-stac PR #229
 
   - Is there more work outstanding on this PR apart from the above release management?

   Edit: DONE

6. Do an odc-stac 0.5.0 release that depends on `odc-loader>=0.6.0`

   Edit: DONE

7. Apply relevant changes to core and remove cores existing `odc-loader<0.6.0` pin.

  Edit: Core PR ready.