### PR TITLE
For 0.5.2 release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
           find ./wheels/clean -type f | xargs twine check
 
       - name: Upload wheels as artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: python-wheels
           path: ./wheels/clean/

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       
       - name: Download wheels from artifacts
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: python-wheels
           path: ./wheels/clean

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "odc-stac"
 description = "Tooling for converting STAC metadata to ODC data model"
-version = "0.5.1"
+version = "0.5.2"
 authors = [
     {name = "Open Data Cube"}
 ]


### PR DESCRIPTION
- Bump versions of upload and download artifact actions, which will hopefully fix the PyPI release workflow.
- Bump odc-stac version to 0.5.2 ready for release.