### PR TITLE
Pass `asset_absolute_paths` to `parse_items`

### DIFF
--- a/odc/stac/_mdtools.py
+++ b/odc/stac/_mdtools.py
@@ -776,7 +776,7 @@ def parse_item(
     """
 
     if template is None or isinstance(template, dict):
-        return next(parse_items([item], template, md_plugin))
+        return next(parse_items([item], template, md_plugin, asset_absolute_paths))
 
     # TODO: remove this part, i.e. template = RasterCollectionMetadata(...)
     # version of this method


### PR DESCRIPTION
`asset_absolute_paths` value was not being passed to `parse_items` when called from `parse_item`