### PR TITLE
Enable absolute paths for accessories

### DIFF
--- a/odc/stac/_mdtools.py
+++ b/odc/stac/_mdtools.py
@@ -874,9 +874,15 @@ def _parse_item(
                 driver_data=driver_data,
             )
 
+    def get_acc_dict(asset: pystac.asset.Asset):
+        asset_dict = asset.to_dict()
+        if asset_absolute_paths:
+            asset_dict["href"] = asset.get_absolute_href()
+        return asset_dict
+
     data_asset_names = set(template.asset_names())
     accessories = {
-        name: asset.to_dict()
+        name: get_acc_dict(asset)
         for name, asset in _assets.items()
         if name not in data_asset_names
     }

--- a/odc/stac/_mdtools.py
+++ b/odc/stac/_mdtools.py
@@ -874,7 +874,7 @@ def _parse_item(
                 driver_data=driver_data,
             )
 
-    def get_acc_dict(asset: pystac.asset.Asset):
+    def _acc_dict(asset: pystac.asset.Asset):
         asset_dict = asset.to_dict()
         if asset_absolute_paths:
             asset_dict["href"] = asset.get_absolute_href()
@@ -882,7 +882,7 @@ def _parse_item(
 
     data_asset_names = set(template.asset_names())
     accessories = {
-        name: get_acc_dict(asset)
+        name: _acc_dict(asset)
         for name, asset in _assets.items()
         if name not in data_asset_names
     }


### PR DESCRIPTION
Get the absolute path for accessories when `asset_absolute_paths` is True, so as to be consistent with the data assets.