### PR TITLE
Add support for Raster extension v2

### DIFF
--- a/odc/stac/_mdtools.py
+++ b/odc/stac/_mdtools.py
@@ -117,10 +117,10 @@ def _get_v2_raster_bands(props: Dict[str, Any]) -> List[RasterBand]:
     def _has_raster_fields(d):
         # the nodata, unit, data_type, and statistics fields are no longer specific
         # to the raster v2.0.0 extension, but we assume they are still associated with it
-        return (
-            any(field in d for field in ["nodata", "unit", "data_type", "statistics"])
-            or any(prop.startswith("raster:") for prop in d)
-        )
+        return any(
+            field in d for field in ["nodata", "unit", "data_type", "statistics"]
+        ) or any(prop.startswith("raster:") for prop in d)
+
     # unlike 'raster:bands', 'bands' does not neccessarily imply the raster
     # extension, and the raster bands may not contain all relevant raster fields
     bands = props.pop("bands", [{}])

--- a/odc/stac/_mdtools.py
+++ b/odc/stac/_mdtools.py
@@ -111,11 +111,34 @@ NON_IMAGE_RASTER_MEDIA_TYPES = {
 }
 
 
+def _get_v2_raster_bands(props: Dict[str, Any]) -> List[RasterBand]:
+    # account for new raster ext conventions and common metadata fields
+    # relevant properties may be in the 'bands' dicts, the asset properties, or both
+    def _has_raster_fields(d):
+        # the nodata, unit, data_type, and statistics fields are no longer specific
+        # to the raster v2.0.0 extension, but we assume they are still associated with it
+        return (
+            any(field in d for field in ["nodata", "unit", "data_type", "statistics"])
+            or any(prop.startswith("raster:") for prop in d)
+        )
+    # unlike 'raster:bands', 'bands' does not neccessarily imply the raster
+    # extension, and the raster bands may not contain all relevant raster fields
+    bands = props.pop("bands", [{}])
+    # if the asset contains raster fields, we can assume any bands are raster bands
+    if _has_raster_fields(props):
+        # there's no need to filter which properties get passed to the RasterBand
+        # since we retrieve specific ones later
+        return [RasterBand({**band, **props}) for band in bands]
+    # otherwise, determine which bands contain raster fields
+    return [RasterBand(band) for band in bands if _has_raster_fields(band)]
+
+
 def _band_metadata_raw(asset: pystac.asset.Asset) -> List[RasterBand]:
-    bands = asset.to_dict().get("raster:bands", None)
-    if bands is None:
-        return []
-    return [RasterBand(props) for props in bands]
+    asset_dict = asset.to_dict()
+    bands = asset_dict.get("raster:bands", None)
+    if bands is not None:
+        return [RasterBand(props) for props in bands]
+    return _get_v2_raster_bands(asset_dict)
 
 
 def band_metadata(
@@ -133,6 +156,10 @@ def band_metadata(
         rext = RasterExtension.ext(asset)
         if rext.bands is not None:
             bands = rext.bands
+        # if the asset defines the raster ext but does not include raster:bands,
+        # assume we're working with the new conventions
+        elif rprops := rext.properties:
+            bands = _get_v2_raster_bands(rprops)
     except pystac.errors.ExtensionNotImplemented:
         bands = _band_metadata_raw(asset)
 

--- a/tests/test_mdtools.py
+++ b/tests/test_mdtools.py
@@ -170,7 +170,78 @@ def test_band_metadata(sentinel_stac_ms_with_raster_ext: pystac.item.Item) -> No
     ]
 
 
-def test_is_raster_data_more() -> None:
+def test_band_metadata_rasterv2() -> None:
+    asset_base = {
+        "href": "http://example.com/asset.tif",
+        "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+        "title": "Raster ext v2 asset",
+        "proj:shape": [5490, 5490],
+        "roles": ["data"],
+    }
+    default_bm = RasterBandMetadata("uint16", 0, "1")
+
+    # raster fields directly in asset
+    asset1 = {
+        **asset_base,
+        "nodata": 0,
+        "data_type": "uint8",
+    }
+    bm = band_metadata(pystac.Asset.from_dict(asset1), default_bm)
+    assert bm == [
+        RasterBandMetadata(data_type="uint8", nodata=0, units="1")
+    ]
+
+    # raster fields only in bands
+    asset2 = {
+        **asset_base,
+        "bands": [{"nodata": 255, "data_type": "int16"}]
+    }
+    bm = band_metadata(pystac.Asset.from_dict(asset2), default_bm)
+    assert bm == [
+        RasterBandMetadata(data_type="int16", nodata=255, units="1")
+    ]
+
+    # second, non-raster band
+    asset3 = {
+        **asset_base,
+        "bands": [
+            {"raster:sampling": "area"},
+            {"eo:cloud_cover": 50.0},
+        ],
+    }
+    bm = band_metadata(pystac.Asset.from_dict(asset3), default_bm)
+    # one raster band that doesn't overwrite the default values
+    assert bm == [default_bm]
+
+    # raster fields in asset means all bands are raster bands
+    asset4 = {
+        **asset_base,
+        "data_type": "float32",
+        "bands": [
+            {"nodata": -999},
+            {"eo:cloud_cover": 50.0},
+        ],
+    }
+    bm = band_metadata(pystac.Asset.from_dict(asset4), default_bm)
+    assert bm == [
+        RasterBandMetadata(data_type="float32", nodata=-999, units="1"),
+        RasterBandMetadata(data_type="float32", nodata=0, units="1")
+    ]
+
+    # only non-raster bands
+    asset5 = {
+        **asset_base,
+        "bands": [
+            {"eo:common_name": "blue"},
+            {"eo:common_name": "red"},
+        ]
+    }
+    bm = band_metadata(pystac.Asset.from_dict(asset5), default_bm)
+    # no raster bands, so the default RasterBandMetadata is returned
+    assert bm == [default_bm]
+
+
+def test_is_reaster_data_more() -> None:
     def _a(href="http://example.com/", **kw):
         return pystac.asset.Asset(href, **kw)
 

--- a/tests/test_mdtools.py
+++ b/tests/test_mdtools.py
@@ -187,19 +187,12 @@ def test_band_metadata_rasterv2() -> None:
         "data_type": "uint8",
     }
     bm = band_metadata(pystac.Asset.from_dict(asset1), default_bm)
-    assert bm == [
-        RasterBandMetadata(data_type="uint8", nodata=0, units="1")
-    ]
+    assert bm == [RasterBandMetadata(data_type="uint8", nodata=0, units="1")]
 
     # raster fields only in bands
-    asset2 = {
-        **asset_base,
-        "bands": [{"nodata": 255, "data_type": "int16"}]
-    }
+    asset2 = {**asset_base, "bands": [{"nodata": 255, "data_type": "int16"}]}
     bm = band_metadata(pystac.Asset.from_dict(asset2), default_bm)
-    assert bm == [
-        RasterBandMetadata(data_type="int16", nodata=255, units="1")
-    ]
+    assert bm == [RasterBandMetadata(data_type="int16", nodata=255, units="1")]
 
     # second, non-raster band
     asset3 = {
@@ -225,7 +218,7 @@ def test_band_metadata_rasterv2() -> None:
     bm = band_metadata(pystac.Asset.from_dict(asset4), default_bm)
     assert bm == [
         RasterBandMetadata(data_type="float32", nodata=-999, units="1"),
-        RasterBandMetadata(data_type="float32", nodata=0, units="1")
+        RasterBandMetadata(data_type="float32", nodata=0, units="1"),
     ]
 
     # only non-raster bands
@@ -234,7 +227,7 @@ def test_band_metadata_rasterv2() -> None:
         "bands": [
             {"eo:common_name": "blue"},
             {"eo:common_name": "red"},
-        ]
+        ],
     }
     bm = band_metadata(pystac.Asset.from_dict(asset5), default_bm)
     # no raster bands, so the default RasterBandMetadata is returned


### PR DESCRIPTION
v2.0.0 of the Raster extension has deprecated `raster:bands` in favour of a single `bands` array that contains both raster and eo bands. Furthermore, as of STAC v1.1.0, the `nodata`, `data_type`, and `unit` fields have become common metadata fields that may now be specified directly in the Asset when shared across all bands.
The pystac `RasterExtension` class does not yet implement the new conventions, so implement our own logic to account for them when retrieving the raster band metadata.