### PR TITLE
readthedocs: fix doc group name

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,7 +12,7 @@ build:
     create_environment:
        - uv venv "${READTHEDOCS_VIRTUALENV_PATH}"
     install:
-       - UV_PROJECT_ENVIRONMENT="${READTHEDOCS_VIRTUALENV_PATH}" UV_LINK_MODE=copy uv sync --frozen --group doc
+       - UV_PROJECT_ENVIRONMENT="${READTHEDOCS_VIRTUALENV_PATH}" UV_LINK_MODE=copy uv sync --frozen --group docs
 
 sphinx:
   builder: html


### PR DESCRIPTION
The group is called docs in this
repository, so use that.