### PR TITLE
Pass wrapdateline=True when computing item footprints

### DIFF
--- a/odc/stac/model.py
+++ b/odc/stac/model.py
@@ -331,7 +331,7 @@ class ParsedItem(Mapping[BandIdentifier, RasterSource | AuxDataSource]):
             if gbox.crs is not None:
                 if crs is None or crs == gbox.crs:
                     return gbox.extent
-                return gbox.footprint(crs)
+                return gbox.footprint(crs, wrapdateline=True)
 
         return None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 dependencies = [
     "affine",
-    "odc-geo>=0.4.7",
+    "odc-geo>=0.5.0",
     "odc-loader>=0.6.4",  # custom fuser support in resolve_load_cfg from 0.6.4
     "rasterio>=1.0.0,!=1.3.0,!=1.3.1",
     "dask[array]",

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -314,3 +314,30 @@ def test_property_load_request_errors() -> None:
     # Test empty sequence
     requests = PropertyLoadRequest.from_user_input([])
     assert len(requests) == 0
+
+
+def test_image_geometry_antimeridian() -> None:
+    # https://github.com/opendatacube/odc-geo/issues/208
+    # UTM zone 1 touches the antimeridian, so the raw footprint is an invalid,
+    # world-spanning polygon and gets silently dropped by grid_intersect.
+    from affine import Affine
+    from odc.geo import CRS
+    from odc.geo.geobox import GeoboxTiles
+
+    gbox = GeoBox(
+        (25129, 29486), Affine(10.0, 0.0, 281870.0, 0.0, -10.0, 7738430.0), "EPSG:32601"
+    )
+    xx = mk_parsed_item([b_("b1", gbox)])
+
+    fp = xx.safe_geometry(CRS("EPSG:4326"))
+    assert fp is not None
+    assert fp.geom.is_valid
+    assert fp.geom.area < 30  # sanity check, not wrapped around the whole globe
+
+    dst = GeoBox(
+        (256, 256),
+        Affine(0.00576000576, 0.0, -179.99945999946, 0.0, -0.00576000576, 69.3029493),
+        "EPSG:4326",
+    )
+    tiles = GeoboxTiles(dst, tile_shape=(256, 256))
+    assert list(tiles.tiles(fp)) == [(0, 0)]


### PR DESCRIPTION
Fixes the odc-stac side of opendatacube/odc-geo#208. Related: #165.

When an item's native geobox sits in a UTM zone touching ±180 (zone 1 or 60), `ParsedItem.image_geometry()` reprojects its footprint into the destination CRS without `wrapdateline`, producing an invalid polygon that spans nearly the whole globe. The `disjoint()` check in `GeoboxTiles.tiles()` then reports no overlap for the tiles the item actually covers, so it never makes it into `tyx_bins` and `odc.stac.load()` returns all nodata--no warning, no error. Easy to mistake for a gap in the source data, in my case it silently wiped out the westernmost column of a global Sentinel-1 mosaic.

odc-geo has handled this case since 0.5.0, via the `wrapdateline` option I added to `GeoBox.footprint()` in opendatacube/odc-geo#234--the flag just never gets passed from this side. So: pass `wrapdateline=True` in `image_geometry()`, and bump the
odc-geo pin from 0.4.7 to 0.5.0 accordingly. `wrapdateline` only kicks in when the destination CRS is geographic, so this
changes nothing for projected destinations.

Minimal example with real data: a Sentinel-1 RTC item over Chukotka (EPSG:32601) from Planetary Computer, loaded into a small EPSG:4326 geobox right at -180: 

```python
import odc.stac
import planetary_computer
import pystac_client
from affine import Affine
from odc.geo.geobox import GeoBox

catalog = pystac_client.Client.open(
    "https://planetarycomputer.microsoft.com/api/stac/v1",
    modifier=planetary_computer.sign_inplace,
)
item = next(catalog.search(
    collections=["sentinel-1-rtc"],
    ids=["S1B_IW_GRDH_1SDV_20200921T183011_20200921T183040_023477_02C993_rtc"],
).items())

# 256x256 EPSG:4326 tile hugging the antimeridian; the item fully covers it
geobox = GeoBox(
    (256, 256),
    Affine(0.00576000576, 0.0, -179.99945999946, 0.0, -0.00576000576, 69.3029493),
    "EPSG:4326",
)
ds = odc.stac.load([item], bands=["vv"], geobox=geobox, nodata=-32768, chunks={})
vv = ds.vv.where(ds.vv != -32768)
print("valid fraction:", float(vv.notnull().mean()))
```

Before: `valid fraction: 0.0` (with `debug=True` you can see the item never makes it into `tyx_bins`). After: `valid fraction: 1.0`, with no changes needed on the odc-geo side.

<img width="1606" height="579" alt="odcstac_antimeridian_before_after_myPR" src="https://github.com/user-attachments/assets/b15bde89-beeb-474a-9fec-12772526282d" />


One thing that makes this extra confusing to debug: whether the invalid footprint "accidentally" passes the intersection test depends on the exact geobox, so nudging the window by a fraction of a pixel can make the problem come and go. Also added a synthetic regression test covering the binning path (fails on main, passes with this change).

This doesn't cover #165's exact reproducer--that one loads into a projected CRS (EPSG:3832), where `wrapdateline` doesn't apply, and looks like a different failure mode (the read window rather than binning, closer to opendatacube/odc-geo#176). But
it's the same class of issue, so linking it here.

For anyone hitting this on a released version, a workaround is to override `ParsedItem.image_geometry` to pass the flag before calling `load()`.